### PR TITLE
Add custom colorchecker

### DIFF
--- a/src/darsia/corrections/color/colorcorrection.py
+++ b/src/darsia/corrections/color/colorcorrection.py
@@ -127,6 +127,9 @@ class ColorCorrection:
         else:
             self.config = {}
 
+        # Check whether colorchecker active
+        self.active = self.config.get("active", True)
+
         # Define ROI
         self.roi: Optional[Union[tuple, np.ndarray]] = None
         if "roi" in self.config:
@@ -169,6 +172,9 @@ class ColorCorrection:
         Returns:
             np.ndarray: corrected image
         """
+        if not self.active:
+            return skimage.img_as_float(image).astype(np.float32)
+
         # Make sure that the image is in uint8 or uint16 format
         if image.dtype in [np.uint8, np.uint16]:
             image = skimage.img_as_float(image)

--- a/src/darsia/corrections/color/colorcorrection.py
+++ b/src/darsia/corrections/color/colorcorrection.py
@@ -264,8 +264,8 @@ class ColorCorrection:
                 "custom_colorchecker_update", False
             )
 
-            # If required, extract swatches from a provided baseline image and use these as reference colors;
-            # otherwise fetch info form file.
+            # If required, extract swatches from a provided baseline image and use these
+            # as reference colors; otherwise fetch info form file.
             if update_colorchecker or not colorchecker_path.exists():
 
                 # Fetch info on baseline image and roi
@@ -281,7 +281,8 @@ class ColorCorrection:
                 )
 
                 # Extract part of the image containing a color checker.
-                # Use width and height (in cm - irrelevant) as provided by the manufacturer Xrite.
+                # Use width and height (in cm - irrelevant) as provided by the
+                # manufacturer Xrite.
                 assert self.roi.shape == (4, 2)
                 colorchecker_img = darsia.extract_quadrilateral_ROI(
                     baseline, pts_src=baseline_roi, width=27.3, height=17.8
@@ -290,7 +291,8 @@ class ColorCorrection:
                 # Determine swatch colors
                 swatches = self._detect_colour_checkers_segmentation(colorchecker_img)
 
-                # Scale to interval [0,1], to not loose any information, perform the scaling by hand
+                # Scale to interval [0,1], to not loose any information, perform the
+                # scaling by hand
                 assert baseline.dtype in [np.uint8, np.uint16]
                 scaling = 255.0 if baseline.dtype == np.uint8 else 255.0**2
                 swatches /= scaling

--- a/src/darsia/corrections/color/colorcorrection.py
+++ b/src/darsia/corrections/color/colorcorrection.py
@@ -62,6 +62,30 @@ class ColorCheckerAfter2014:
         )
 
 
+class CustomColorChecker:
+    """Swatch colors determined from user-prescribed input image."""
+
+    def __init__(
+        self, path: Path, reference_colors: Optional[np.ndarray] = None
+    ) -> None:
+        """
+        Either read reference colors from file or from provided array.
+        If colors are provided, these will be prioritized and also written to file.
+
+        Args:
+            path (Path): path for storing and fetching reference colors
+            colors (np.ndarray, optional): reference RGB colors
+        """
+
+        # Prioritize colors if provided.
+        if reference_colors is None:
+            self.reference_swatches_rgb = np.load(path)
+
+        else:
+            self.reference_swatches_rgb = reference_colors
+            np.save(path, reference_colors)
+
+
 class ColorCorrection:
     """ML-free color correction.
 


### PR DESCRIPTION
As alternative to the Classic ColorChecker which stores the reference colors of the color palette as provided by the manufacturer Calibrite, an additional Custom ColorChecker object is added. It allows to define own reference colors, e.g., colors based on a baseline image. The option to learn a custom color checker from a baseline image is added to the `ColorCorrection` class.