### PR TITLE
Compaction analysis for patches

### DIFF
--- a/examples/compaction_analysis.py
+++ b/examples/compaction_analysis.py
@@ -122,15 +122,18 @@ plt.imshow(img_box_B.img)
 plt.show()
 
 # Now we patch box B, the number of patches is arbitrary (here chosen to be 5 x 3):
-patches_box_B = darsia.Patches(img_box_B, 5, 3)
+patched_box_B = darsia.Patches(img_box_B, 5, 3)
 
-# The patch centers can be accessed:
-patch_centers_box_B = patches_box_B.global_centers_cartesian
+# The patch centers can be accessed - actually not required here, but these correspond
+# to the subsequent deformations.
+patch_centers_box_B = patched_box_B.global_centers_cartesian_matrix
+print(patch_centers_box_B)
 
 # The deformation in the centers of these points can be obtained by evaluating the
-# deformation map in a similar fashion as above. The results comes in a matrix.
-# Entry [row,col] is associated to patch with coordinate [row,col] using the
-# conventional matrix indexing.
-deformation_patch_centers_box_B = compaction_analysis.evaluate(patch_centers_box_B)
+# deformation map in a patch object. The result uses conventional matrix indexing.
+# Entry [row,col] is associated to patch with coordinate [row,col], with [0,0]
+# denoting the top left corner of the image/patch.
+deformation_patch_centers_box_B = compaction_analysis.evaluate(patched_box_B)
+
 print("The deformation in the centers of the patches of Box B:")
 print(deformation_patch_centers_box_B)

--- a/src/darsia/analysis/compactionanalysis.py
+++ b/src/darsia/analysis/compactionanalysis.py
@@ -2,6 +2,8 @@
 Module containing tools for studying compaction.
 """
 
+from typing import Union
+
 import numpy as np
 
 import darsia
@@ -90,14 +92,18 @@ class CompactionAnalysis:
             return transformed_img
 
     def evaluate(
-        self, coords: np.ndarray, reverse: bool = True, units: str = "metric"
+        self,
+        coords: Union[np.ndarray, darsia.Patches],
+        reverse: bool = True,
+        units: str = "metric",
     ) -> np.ndarray:
         """
         Evaluate compaction in arbitrary points.
 
         Args:
-            coords (np.ndarray): coordinate array with shape num_pts x 2, or alternatively
-                num_x_pts x num_y_pts x 2, identifying points in a mesh/patched image.
+            coords (np.ndarray, or darsia.Patches): coordinate array with shape num_pts x 2,
+                or alternatively num_rows_pts x num_cols_pts x 2, identifying points in a
+                mesh/patched image, or equivalently patch.
             reverse (bool): flag whether the translation is understood as from the
                 test image to the baseline image, or reversed. The default is the
                 former latter.
@@ -108,6 +114,9 @@ class CompactionAnalysis:
             np.ndarray: compaction vectors for all coordinates.
 
         """
+        if isinstance(coords, darsia.Patches):
+            coords = coords.global_centers_cartesian_matrix
+
         assert units in ["metric", "pixel"]
         assert coords.shape[-1] == 2
 

--- a/src/darsia/image/patches.py
+++ b/src/darsia/image/patches.py
@@ -159,7 +159,39 @@ class Patches:
             ]
         )
 
+        # Store centers (x,y) of each patch in global Cartesian coordinates and metric units,
+        # but ordered using matrix indexing
+        self.global_centers_cartesian_matrix = np.array(
+            [
+                [
+                    self.base.origo
+                    + np.array(
+                        [
+                            (i + 0.5) * patch_width_metric,
+                            (self.num_patches_y - (j + 0.5)) * patch_height_metric,
+                        ]
+                    )
+                    for i in range(self.num_patches_x)
+                ]
+                for j in range(self.num_patches_y)
+            ]
+        )
+
         # Convert coordinates of patch centers to pixels - using the matrix indexing
+        self.global_centers_matrix = np.array(
+            [
+                [
+                    self.base.coordinatesystem.coordinateToPixel(
+                        self.global_centers_cartesian[i, self.num_patches_y - 1 - j]
+                    )
+                    for i in range(self.num_patches_x)
+                ]
+                for j in range(self.num_patches_y)
+            ],
+            dtype=int,
+        )
+
+        # Convert coordinates of patch centers to pixels - using the reverse matrix indexing
         self.global_centers_reverse_matrix = np.array(
             [
                 [


### PR DESCRIPTION
Extend evaluation capabilities of `CompactionAnalysis` and allow for the evaluation of patches. The returned result is conforming with the result of `__call__`, i.e., a deformation map with analogous dimensions as the patch, using matrix indexing.