### PR TITLE
Default setup of folder and standard baseline for colorcorrection

### DIFF
--- a/src/darsia/corrections/color/colorcorrection.py
+++ b/src/darsia/corrections/color/colorcorrection.py
@@ -83,6 +83,7 @@ class CustomColorChecker:
 
         else:
             self.reference_swatches_rgb = reference_colors
+            path.parents[0].mkdir(parents=True, exist_ok=True)
             np.save(path, reference_colors)
 
 
@@ -270,7 +271,7 @@ class ColorCorrection:
 
                 # Fetch info on baseline image and roi
                 baseline_path: str = self.config.get(
-                    "custom_colorchecker_reference_image"
+                    "baseline"
                 )
                 baseline = cv2.cvtColor(
                     cv2.imread(str(Path(baseline_path)), cv2.IMREAD_UNCHANGED),

--- a/src/darsia/manager/analysisbase.py
+++ b/src/darsia/manager/analysisbase.py
@@ -54,7 +54,13 @@ class AnalysisBase:
         self.drift_correction = darsia.DriftCorrection(
             base=reference_base, config=self.config["drift"]
         )
+
+        # Define color correction and provide baseline to colorchecker
+        if "baseline" not in self.config["color"]:
+            self.config["color"]["baseline"] = reference_base
         self.color_correction = darsia.ColorCorrection(config=self.config["color"])
+
+        # Define curvature correction
         self.curvature_correction = darsia.CurvatureCorrection(
             config=self.config["curvature"]
         )


### PR DESCRIPTION
Circumvent error message when path not existent.

The color correction uses now the reference baseline image as default when setting up a custom color checker. This allows for cleaner config files.