### PR TITLE
Absolute translation correction

### DIFF
--- a/src/darsia/corrections/shape/translation.py
+++ b/src/darsia/corrections/shape/translation.py
@@ -2,6 +2,7 @@
 Module containing estimator for translation required to match two images.
 """
 
+from pathlib import Path
 from typing import Optional, Union
 
 import cv2
@@ -355,3 +356,39 @@ class TranslationEstimator:
 
         # Procedure successful - return the translation
         return affine_translation, True
+
+
+class TranslationCorrection:
+    """Correction object performing a user-prescribed translation to provided image."""
+
+    def __init__(self, translation: Optional[Union[str, Path]] = None):
+
+        # Read translation from file
+        if translation is not None:
+            self.translation = np.load(Path(translation))
+            self.active = True
+        else:
+            self.active = False
+
+    def __call__(self, img: Union[np.ndarray, darsia.Image]) -> Optional[np.ndarray]:
+        """
+        Perform translation.
+
+        Args:
+            img (np.ndarray or darsia.Image): image to be corrected.
+
+        Returns:
+            Corrected image as np.ndarray if input has been an array,
+            otherwise None.
+        """
+
+        # Apply translation - Modify darsia Image internally
+        if isinstance(img, np.ndarray):
+            (h, w) = img.shape[:2]
+            translated_img = cv2.warpAffine(img, self.translation, (w, h))
+            return translated_img
+        elif isinstance(img, darsia.Image):
+            (h, w) = img.img.shape[:2]
+            img.img = cv2.warpAffine(img.img, self.translation, (w, h))
+        else:
+            raise ValueError("Input has non-supported type.")

--- a/src/darsia/image/image.py
+++ b/src/darsia/image/image.py
@@ -54,6 +54,7 @@ class Image:
         img: Union[np.ndarray, str, Path],
         metadata: Optional[dict] = None,
         drift_correction: Optional[da.DriftCorrection] = None,
+        translation_correction: Optional[da.TranslationCorrection] = None,
         color_correction: Optional[da.ColorCorrection] = None,
         curvature_correction: Optional[da.CurvatureCorrection] = None,
         **kwargs,
@@ -69,6 +70,8 @@ class Image:
             img (Union[np.ndarray, str, Path]): image array with matrix indexing
             metadata (dict, Optional): metadata dictionary, default is None.
             drift_correction (darsia.DriftCorrection, Optional): Drift correction object.
+            translation_correction (darsia.TranslationCorrection, Optional): Translation
+                correction object.
             color_correction (darsia.ColorCorrection, Optional): Color correction object.
                 Default is none, but should be included if the image is to be color
                 corrected at initialization.
@@ -165,6 +168,9 @@ class Image:
 
         if color_correction is not None:
             self.img = color_correction(self.img)
+
+        if translation_correction is not None:
+            self.img = translation_correction(self.img)
 
         if curvature_correction is not None:
             self.img = curvature_correction(self.img)

--- a/src/darsia/manager/analysisbase.py
+++ b/src/darsia/manager/analysisbase.py
@@ -51,6 +51,12 @@ class AnalysisBase:
         self.processed_baseline_images = None
 
         # Define correction objects
+        self.translation_correction = (
+            darsia.TranslationCorrection(translation=self.config["translation"])
+            if "translation" in self.config
+            else None
+        )
+
         self.drift_correction = darsia.DriftCorrection(
             base=reference_base, config=self.config["drift"]
         )
@@ -83,6 +89,7 @@ class AnalysisBase:
         return darsia.Image(
             img=path,
             drift_correction=self.drift_correction,
+            translation_correction=self.translation_correction,
             curvature_correction=self.curvature_correction,
             color_correction=self.color_correction,
         )


### PR DESCRIPTION
A new standard correction object is introduced. It applies an absolute translation/drift to an image. This is also included in the standard analysis workflow.

Example use case: When comparing two different sets of experiments, they may be recorded in different settings. While the drift correction is responsible to correct for relative translation wrt. the baseline image of the respective experiment, an additional absolute translation correction can be applied to correct for the difference between the baseline images. Here, it is for now assumed that the translation is provided directly as affine matrix.