### PR TITLE
Renamed all instances of origo to origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ The following Python script can be applied to the test image in the examples/ima
 import darsia as da
 
 # Create a darsia Image: An image that also contains information of physical entities
-image = da.Image("examples/images/baseline.jpg", origo = [5, 2], width = 280, height = 150)
+image = da.Image("examples/images/baseline.jpg", origin = [5, 2], width = 280, height = 150)
 
 # Use the show method to take a look at the imported image (push any button to close the window)
 image.show()
 
 # Copies the image and adds a grid on top of it.
-grid_image = image.add_grid(origo = [5, 2], dx = 10, dy = 10)
+grid_image = image.add_grid(origin = [5, 2], dx = 10, dy = 10)
 grid_image.show()
 
 # Extract region of interest (ROI) from image:

--- a/examples/notebooks/brief_tutorial.ipynb
+++ b/examples/notebooks/brief_tutorial.ipynb
@@ -35,7 +35,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "baseline_image = da.Image(\"../images/baseline.jpg\", origo=(5,0), width = 280, height = 150)"
+    "baseline_image = da.Image(\"../images/baseline.jpg\", origin=(5,0), width = 280, height = 150)"
    ]
   },
   {
@@ -136,7 +136,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.7 64-bit (system)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -150,12 +150,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.7"
+   "version": "3.10.9 (tags/v3.10.9:1dd9be6, Dec  6 2022, 20:01:21) [MSC v.1934 64 bit (AMD64)]"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "408475a283c45cf9f7261fa76ad05b2967f627503c1ee969ffe623e82a04e6f7"
+    "hash": "3060e18010d58dda700e9ce9bc7cf797083ee39fbec6e65ed237d0e2634cd9e0"
    }
   }
  },

--- a/src/darsia/analysis/translationanalysis.py
+++ b/src/darsia/analysis/translationanalysis.py
@@ -270,12 +270,12 @@ class TranslationAnalysis:
         if units[0] == "metric":
             # Add the left vertical boundary
             vertical_boundary += [
-                self.base.origo + np.array([0, y_pos])
+                self.base.origin + np.array([0, y_pos])
                 for y_pos in np.linspace(0, self.base.height, self.N_patches[1] + 1)
             ]
             # Add the right vertical boundary
             vertical_boundary += [
-                self.base.origo + np.array([self.base.width, y_pos])
+                self.base.origin + np.array([self.base.width, y_pos])
                 for y_pos in np.linspace(0, self.base.height, self.N_patches[1] + 1)
             ]
 
@@ -321,7 +321,7 @@ class TranslationAnalysis:
         if units[0] == "metric":
             # Add the bottom horizontal boundary
             horizontal_boundary += [
-                self.base.origo + np.array([x_pos, 0])
+                self.base.origin + np.array([x_pos, 0])
                 for x_pos in np.linspace(0, self.base.width, self.N_patches[0] + 1)
             ]
 

--- a/src/darsia/image/coordinatesystem.py
+++ b/src/darsia/image/coordinatesystem.py
@@ -27,7 +27,7 @@ class CoordinateSystem:
 
         # Determine the coordinate, corresponding to the origin pixel (0,0), i.e.,
         # the top left corner.
-        self._coordinate_of_origin_pixel: np.ndarray = img.origo + np.array(
+        self._coordinate_of_origin_pixel: np.ndarray = img.origin + np.array(
             [0, img.height]
         )
 

--- a/src/darsia/image/image.py
+++ b/src/darsia/image/image.py
@@ -1,6 +1,6 @@
 """Image class.
 
-Images contain the image array, and in addition metadata about origo and dimensions.
+Images contain the image array, and in addition metadata about origin and dimensions.
 """
 
 from __future__ import annotations
@@ -27,7 +27,7 @@ class Image:
 
     Contains the actual image, as well as meta data, i.e., base properties such as
     position in global coordinates, width and height. One can either pass in metadata
-    (origo, width and height, amongst other entities) by passing them directly to
+    (origin, width and height, amongst other entities) by passing them directly to
     the constructor or through a metadata-file (default is to pass metadata diretly
     to the constructor. If a metadatafile is required, the "read_metadata_from_file"
     variable has to be passed as True). Image can either be passed in as numpy array
@@ -40,7 +40,7 @@ class Image:
         metadata (dict):
             width (float): physical width of the image
             height (float): physical height of the image
-            origo (np.ndarray): physical coordinates of the lower left corner, i.e.,
+            origin (np.ndarray): physical coordinates of the lower left corner, i.e.,
                 of the (img.shape[0],0) pixel
             color_space (str): Color space (RGB/BGR/RED/GREEN/BLUE/GRAY)
             timestamp (datetime.datetime): timestamp of the image in (default) datetime format.
@@ -80,9 +80,9 @@ class Image:
                 if the image is to be curvature corrected at initialization
             kwargs (Optional arguments)
                 metadata_source (str): Path to a metadata json-file that provides
-                    metadata such as physical width, height and origo of image
+                    metadata such as physical width, height and origin of image
                     as well as  color space
-                origo (np.ndarray): physical coordinates of the lower left corner
+                origin (np.ndarray): physical coordinates of the lower left corner
                 width (float): physical width of the image
                 height (float): physical height of the image
                 color_space (str): the color space of the image. So far only BGR
@@ -117,7 +117,7 @@ class Image:
             else:
                 raise Exception("image height not specified")
 
-            self.metadata["origo"] = np.array(kwargs.pop("origo", np.array([0, 0])))
+            self.metadata["origin"] = np.array(kwargs.pop("origin", np.array([0, 0])))
 
             no_colorspace_given = "color_space" not in kwargs
             self.metadata["color_space"] = kwargs.pop("color_space", "BGR")
@@ -201,8 +201,8 @@ class Image:
     # ! ---- Fast-access getter functions for metadata
 
     @property
-    def origo(self) -> np.ndarray:
-        return self.metadata["origo"]
+    def origin(self) -> np.ndarray:
+        return self.metadata["origin"]
 
     @property
     def width(self) -> float:
@@ -321,7 +321,7 @@ class Image:
     # Seems like something that should read an image and return a new one with grid.
     def add_grid(
         self,
-        origo: Optional[Union[np.ndarray, list[float]]] = None,
+        origin: Optional[Union[np.ndarray, list[float]]] = None,
         dx: float = 1,
         dy: float = 1,
         color: tuple = (0, 0, 125),
@@ -331,7 +331,7 @@ class Image:
         Adds a grid on the image and returns new image.
 
         Arguments:
-            origo (np.ndarray): origo of the grid, in physical units - the reference
+            origin (np.ndarray): origin of the grid, in physical units - the reference
                 coordinate system is provided by the corresponding attribute coordinatesystem
             dx (float): grid size in x-direction, in physical units
             dy (float): grid size in y-direction, in physical units
@@ -341,11 +341,11 @@ class Image:
         Returns:
             Image: original image with grid on top
         """
-        # Set origo if it was not provided
-        if origo is None:
-            origo = self.metadata["origo"]
-        elif isinstance(origo, list):
-            origo = np.array(origo)
+        # Set origin if it was not provided
+        if origin is None:
+            origin = self.metadata["origin"]
+        elif isinstance(origin, list):
+            origin = np.array(origin)
 
         # Determine the number of grid lines required
         num_horizontal_lines: int = math.ceil(self.metadata["height"] / dy) + 1
@@ -362,7 +362,7 @@ class Image:
             xmax = self.coordinatesystem.domain["xmax"]
 
             # Determine the y coordinate of the line
-            y = origo[1] + i * dy
+            y = origin[1] + i * dy
 
             # Determine the pixels corresponding to the end points of the horizontal line
             # (xmin,y) - (xmax,y), in (row,col) format.
@@ -384,7 +384,7 @@ class Image:
             ymax = self.coordinatesystem.domain["ymax"]
 
             # Determine the y coordinate of the line
-            x = origo[0] + j * dx
+            x = origin[0] + j * dx
 
             # Determine the pixels corresponding to the end points of the vertical line
             # (x, ymin) - (x, ymax), in (row,col) format.

--- a/src/darsia/image/patches.py
+++ b/src/darsia/image/patches.py
@@ -146,7 +146,7 @@ class Patches:
         self.global_centers_cartesian = np.array(
             [
                 [
-                    self.base.origo
+                    self.base.origin
                     + np.array(
                         [
                             (i + 0.5) * patch_width_metric,
@@ -164,7 +164,7 @@ class Patches:
         self.global_centers_cartesian_matrix = np.array(
             [
                 [
-                    self.base.origo
+                    self.base.origin
                     + np.array(
                         [
                             (i + 0.5) * patch_width_metric,
@@ -225,7 +225,7 @@ class Patches:
                             ],
                         ]
                     )
-                    + self.base.origo[np.newaxis, :]
+                    + self.base.origin[np.newaxis, :]
                     for j in range(self.num_patches_y)
                 ]
                 for i in range(self.num_patches_x)
@@ -484,7 +484,7 @@ class Patches:
         # Define resulting darsia image
         da_assembled_img = da.Image(
             img=assembled_img,
-            origo=self.base.origo,
+            origin=self.base.origin,
             width=self.base.width,
             height=self.base.height,
             color_space=self.base.colorspace,
@@ -575,7 +575,7 @@ class Patches:
         # Define resulting darsia image
         da_assembled_img = da.Image(
             img=assembled_img,
-            origo=self.base.origo,
+            origin=self.base.origin,
             width=self.base.width,
             height=self.base.height,
             color_space=self.base.colorspace,

--- a/src/darsia/image/subregions.py
+++ b/src/darsia/image/subregions.py
@@ -51,7 +51,7 @@ def extractROI(
         warnings.warn("Provided coordinates lie outside image.")
 
     # Define metadata (all quantities in metric units)
-    origo = [np.min(pts[:, 0]), np.min(pts[:, 1])]
+    origin = [np.min(pts[:, 0]), np.min(pts[:, 1])]
     width = np.max(pts[:, 0]) - np.min(pts[:, 0])
     height = np.max(pts[:, 1]) - np.min(pts[:, 1])
 
@@ -60,7 +60,7 @@ def extractROI(
         return (
             darsia.Image(
                 img=img.img[roi],
-                origo=origo,
+                origin=origin,
                 width=width,
                 height=height,
                 color_space=img.colorspace,
@@ -70,7 +70,7 @@ def extractROI(
     else:
         return darsia.Image(
             img=img.img[roi],
-            origo=origo,
+            origin=origin,
             width=width,
             height=height,
             color_space=img.colorspace,
@@ -87,9 +87,9 @@ def extractROIPixel(img: darsia.Image, roi: tuple) -> darsia.Image:
     Returns:
         darsia.Image: image object restricted to the ROI.
     """
-    # Define metadata; Note that img.origo uses a Cartesian indexing, while the
+    # Define metadata; Note that img.origin uses a Cartesian indexing, while the
     # roi uses the conventional matrix indexing
-    origo = img.origo + np.array(
+    origin = img.origin + np.array(
         [roi[1].start * img.dx, (img.num_pixels_height - roi[0].stop) * img.dy]
     )
     height = (roi[0].stop - roi[0].start) * img.dy
@@ -98,7 +98,7 @@ def extractROIPixel(img: darsia.Image, roi: tuple) -> darsia.Image:
     # Construct and return image corresponding to ROI
     return darsia.Image(
         img=img.img[roi],
-        origo=origo,
+        origin=origin,
         width=width,
         height=height,
         color_space=img.colorspace,


### PR DESCRIPTION
For some reason I assumed that origo was an English word, but it looks like it is not. I changed (hopefully) all apperances of the word in DarSIA. 

I am not sure whether it is used in any external library (fluidflower/porotwin) so perhaps we need to take care?