### PR TITLE
Feature/image subtract

### DIFF
--- a/src/darsia/image/image.py
+++ b/src/darsia/image/image.py
@@ -240,8 +240,11 @@ class Image:
         """
         if self.img.shape != other.img.shape:
             warn("Images have different shapes. Resizing second argument to match.")
-            other_img = cv2.resize(other.img, self.img.shape[::-1][1:3])
-            return da.Image(self.img - other_img, copy.copy(self.metadata))
+            return da.Image(
+                self.img
+                - cv2.resize(np.copy(other.img), tuple(reversed(self.img.shape[:2]))),
+                copy.copy(self.metadata),
+            )
         else:
             return da.Image(self.img - other.img, copy.copy(self.metadata))
 

--- a/src/darsia/image/image.py
+++ b/src/darsia/image/image.py
@@ -228,7 +228,24 @@ class Image:
     def original_dtype(self) -> np.dtype:
         return self.metadata["original_dtype"]
 
-    # ! ---- Corresponding setter functions for metadata
+    # ! ---- Operation overloaders
+    def __sub__(self, other: da.Image):
+        """Subtract two images.
+
+        Arguments:
+            other (Image): image to subtract from self
+
+        Returns:
+            Image: difference image
+        """
+        if self.img.shape != other.img.shape:
+            warn("Images have different shapes. Resizing second argument to match.")
+            other_img = cv2.resize(other.img, self.img.shape[::-1][1:3])
+            return da.Image(self.img-other_img, copy.copy(self.metadata))
+        else:
+            return da.Image(self.img-other.img, copy.copy(self.metadata))
+
+
 
     def write(
         self,

--- a/src/darsia/image/image.py
+++ b/src/darsia/image/image.py
@@ -242,7 +242,7 @@ class Image:
             warn("Images have different shapes. Resizing second argument to match.")
             return da.Image(
                 self.img
-                - cv2.resize(np.copy(other.img), tuple(reversed(self.img.shape[:2]))),
+                - cv2.resize(other.img, tuple(reversed(self.img.shape[:2]))),
                 copy.copy(self.metadata),
             )
         else:

--- a/src/darsia/image/image.py
+++ b/src/darsia/image/image.py
@@ -241,11 +241,9 @@ class Image:
         if self.img.shape != other.img.shape:
             warn("Images have different shapes. Resizing second argument to match.")
             other_img = cv2.resize(other.img, self.img.shape[::-1][1:3])
-            return da.Image(self.img-other_img, copy.copy(self.metadata))
+            return da.Image(self.img - other_img, copy.copy(self.metadata))
         else:
-            return da.Image(self.img-other.img, copy.copy(self.metadata))
-
-
+            return da.Image(self.img - other.img, copy.copy(self.metadata))
 
     def write(
         self,

--- a/src/darsia/image/image.py
+++ b/src/darsia/image/image.py
@@ -241,8 +241,7 @@ class Image:
         if self.img.shape != other.img.shape:
             warn("Images have different shapes. Resizing second argument to match.")
             return da.Image(
-                self.img
-                - cv2.resize(other.img, tuple(reversed(self.img.shape[:2]))),
+                self.img - cv2.resize(other.img, tuple(reversed(self.img.shape[:2]))),
                 copy.copy(self.metadata),
             )
         else:

--- a/src/darsia/mathematics/regularization.py
+++ b/src/darsia/mathematics/regularization.py
@@ -43,6 +43,9 @@ def tv_denoising(
     # Set verbosity of stopping criterion
     tvd_stoppingCriterion.verbose = verbose
 
+    # Copy the input image
+    img = img.copy()
+
     # Extract the two images
     rhs = skimage.img_as_float(img.img)
     im = skimage.img_as_float(img.img)


### PR DESCRIPTION
Tried out operation overload to allow subtraction of DarSIA images. It is a small thing, and if used carelessly it can be a bad practice, but it is also convenient. What do you think?

Could also include more checks to check whether metadata coincide as well?