### PR TITLE
Replace pytest.skip with pytest.xfail

### DIFF
--- a/tests/integration/test_segmentation.py
+++ b/tests/integration/test_segmentation.py
@@ -103,7 +103,6 @@ class LargeRigCO2Analysis(LargeFluidFlower, FluidFlowerCO2Analysis):
         return np.logical_and(co2.img, np.logical_not(self.esf_sand))
 
 
-@pytest.mark.skip(reason="Requires files which are only locally available.")
 def test_integrated_segmentation():
     """Test whether phase segmentation prodcues a reference result.
 
@@ -117,37 +116,40 @@ def test_integrated_segmentation():
     folder = Path("segmentation")
     images_folder = folder / Path("images")
     images_exist = len(list(sorted(images_folder.glob("*.TIF")))) > 0
-    if images_exist:
-        images = list(sorted(images_folder.glob("*.TIF")))[10]
-        baseline = list(sorted(images_folder.glob("*.TIF")))[:10]
-        config = folder / Path("config.json")
-        results = folder / Path("results")
-        results.mkdir(parents=True, exist_ok=True)
 
-        # Define FluidFlower based on a full set of basline images
-        analysis = LargeRigCO2Analysis(
-            baseline=baseline,  # paths to baseline images
-            config=config,  # path to config file
-            results=results,  # path to results directory
-        )
+    if not images_exist:
+        pytest.xfail("Images required for test not available.")
 
-        # Perform standardized CO2 batch analysis
-        analysis.batch_analysis(images, plot_contours=False, write_contours=True)
+    images = list(sorted(images_folder.glob("*.TIF")))[10]
+    baseline = list(sorted(images_folder.glob("*.TIF")))[:10]
+    config = folder / Path("config.json")
+    results = folder / Path("results")
+    results.mkdir(parents=True, exist_ok=True)
 
-        # Compare reference phase segmentation with newly computed - make a
-        # pixel-by-pixel comparison
-        ref_results = Path("segmentation/results/contour_plots/reference.jpg")
-        new_results = Path(
-            "segmentation/results/contour_plots/211124_time124600_DSC00842_with_contours.jpg"
-        )
-        ref = cv2.imread(str(ref_results))
-        new = cv2.imread(str(new_results))
-        diff = np.linalg.norm(ref - new)
-        assert np.isclose(diff, 0.0)
+    # Define FluidFlower based on a full set of basline images
+    analysis = LargeRigCO2Analysis(
+        baseline=baseline,  # paths to baseline images
+        config=config,  # path to config file
+        results=results,  # path to results directory
+    )
 
-        # Remove new results
-        new_results.unlink()
+    # Perform standardized CO2 batch analysis
+    analysis.batch_analysis(images, plot_contours=False, write_contours=True)
 
-        # Remove cache folder
-        cache_folder = Path("cache")
-        shutil.rmtree(cache_folder)
+    # Compare reference phase segmentation with newly computed - make a
+    # pixel-by-pixel comparison
+    ref_results = Path("segmentation/results/contour_plots/reference.jpg")
+    new_results = Path(
+        "segmentation/results/contour_plots/211124_time124600_DSC00842_with_contours.jpg"
+    )
+    ref = cv2.imread(str(ref_results))
+    new = cv2.imread(str(new_results))
+    diff = np.linalg.norm(ref - new)
+    assert np.isclose(diff, 0.0)
+
+    # Remove new results
+    new_results.unlink()
+
+    # Remove cache folder
+    cache_folder = Path("cache")
+    shutil.rmtree(cache_folder)

--- a/tests/unit/test_correction.py
+++ b/tests/unit/test_correction.py
@@ -1,5 +1,6 @@
 import json
 import os
+from pathlib import Path
 
 import cv2
 import numpy as np
@@ -64,9 +65,10 @@ def test_color_correction():
     # ! ---- Compare corrected image with reference
 
     # Load reference image
-    reference_image = np.load(
-        "../reference/color_corrected_baseline.npy", allow_pickle=True
-    )
+    reference_path = "../reference/color_corrected_baseline.npy"
+    if not Path(reference_path).exists():
+        pytest.xfail("Image required for test not available.")
+    reference_image = np.load(reference_path, allow_pickle=True)
 
     # Make a direct comparison
     assert np.all(np.isclose(reference_image, image.img))
@@ -99,9 +101,12 @@ def test_curvature_correction():
 
     # ! ---- Compare corrected image with reference
 
-    reference_image = np.load(
-        "../reference/curvature_corrected_co2_2.npy", allow_pickle=True
-    )
+    reference_path = "../reference/curvature_corrected_co2_2.npy"
+    if not Path(reference_path).exists():
+        pytest.xfail("Image required for test not available.")
+    reference_image = np.load(reference_path, allow_pickle=True)
+
+    # Make a direct comparison
     assert np.all(np.isclose(reference_image, image.img))
 
 

--- a/tests/unit/test_correction.py
+++ b/tests/unit/test_correction.py
@@ -27,15 +27,19 @@ def read_test_image(img_id: str) -> tuple[np.ndarray, dict]:
         "indexing": "ij",
     }
 
-    return array, info
+    success = array is not None
+
+    return array, info, success
 
 
-@pytest.mark.skip(reason="Requires files which are only locally available.")
 def test_color_correction():
     """Test color correction, effectively converting from BGR to RGB."""
 
     # ! ---- Fetch test image
-    array, info = read_test_image("baseline")
+    array, info, success = read_test_image("baseline")
+
+    if not success:
+        pytest.xfail("Image required for test not available.")
 
     # ! ---- Setup color correction
 
@@ -68,14 +72,16 @@ def test_color_correction():
     assert np.all(np.isclose(reference_image, image.img))
 
 
-@pytest.mark.skip(reason="Requires files which are only locally available.")
 def test_curvature_correction():
     """Test of curvature correction applied to a numpy array. The correction
     routine contains all relevant operations, incl. bulging, stretching, and
     cropping."""
 
     # ! ---- Fetch test image
-    array, info = read_test_image("co2_2")
+    array, info, success = read_test_image("co2_2")
+
+    if not success:
+        pytest.xfail("Image required for test not available.")
 
     # ! ---- Setup correction
 
@@ -103,7 +109,11 @@ def test_drift_correction():
     """Test the relative aligning of images via a drift."""
 
     # ! ---- Fetch test images
-    original_array, info = read_test_image("baseline")
+    original_array, info, success = read_test_image("baseline")
+
+    if not success:
+        pytest.xfail("Image required for test not available.")
+
     original_image = darsia.Image(img=original_array, **info)
 
     # ! ---- Define drift correction

--- a/tests/unit/test_image_registration.py
+++ b/tests/unit/test_image_registration.py
@@ -31,16 +31,20 @@ def read_test_image(img_id: str) -> tuple[np.ndarray, dict]:
         "orientation": "ij",
     }
 
-    return array, info
+    success = array is not None
+
+    return array, info, success
 
 
-@pytest.mark.skip(reason="Requires files which are only locally available.")
 def test_image_registration():
     """Test the local patchwise affine correction."""
 
     # ! ---- Fetch image arrays
-    array_dst, info = read_test_image("fine/Baseline")
-    array_src, _ = read_test_image("fine/pulse1")
+    array_dst, info, success_dst = read_test_image("fine/Baseline")
+    array_src, _, success_src = read_test_image("fine/pulse1")
+
+    if not (success_dst and success_src):
+        pytest.xfail("Files required for test not available.")
 
     # ! ---- Transformations
 

--- a/tests/unit/test_image_registration.py
+++ b/tests/unit/test_image_registration.py
@@ -4,6 +4,8 @@ Module testing the image registration and local warping of images.
 """
 
 import os
+from pathlib import Path
+from typing import Optional
 
 import cv2
 import numpy as np
@@ -12,7 +14,7 @@ import pytest
 import darsia
 
 
-def read_test_image(img_id: str) -> tuple[np.ndarray, dict]:
+def read_test_image(img_id: str) -> tuple[Optional[np.ndarray], Optional[dict], bool]:
     """Centralize reading of test image.
 
     Returns:
@@ -23,17 +25,18 @@ def read_test_image(img_id: str) -> tuple[np.ndarray, dict]:
 
     # ! ---- Define image array in RGB format
     path = f"{os.path.dirname(__file__)}/../../examples/images/{img_id}.jpg"
-    array = cv2.cvtColor(cv2.imread(path), cv2.COLOR_BGR2RGB)
+    if Path(path).exists():
+        array = cv2.cvtColor(cv2.imread(path), cv2.COLOR_BGR2RGB)
 
-    # ! ---- Define some metadata corresponding to the input array
-    info = {
-        "dim": 2,
-        "orientation": "ij",
-    }
+        # ! ---- Define some metadata corresponding to the input array
+        info = {
+            "dim": 2,
+            "orientation": "ij",
+        }
 
-    success = array is not None
-
-    return array, info, success
+        return array, info, True
+    else:
+        return None, None, False
 
 
 def test_image_registration():


### PR DESCRIPTION
Replacing pytest.skip with pytest.xfail allows local testing when possible. Tests remain expected to fail due to lacking data (large images).