### PR TITLE
Image arithmetics tested for equidimensional reconstriction of mixed-dimensional vtu data

### DIFF
--- a/examples/vtu_images.py
+++ b/examples/vtu_images.py
@@ -33,4 +33,4 @@ porosity_1d = 1.0
 vtu_image = darsia.superpose(
     [darsia.weight(vtu_image_2d, porosity_2d), darsia.weight(vtu_image_1d, porosity_1d)]
 )
-vtu_image.show("equi-dimensionsional reconstruction")
+vtu_image.show("equi-dimensionsional reconstruction", 5)

--- a/examples/vtu_images.py
+++ b/examples/vtu_images.py
@@ -1,0 +1,36 @@
+"""Example of reading and resampling vtu images corresponding
+to mixed-dimensional data. For this, embed the one-dimensional data
+and superpose both, weighted by a dimensionally relevant quantity.
+
+"""
+
+from pathlib import Path
+
+import darsia
+
+# Read two-dimensional vtu image (standard)
+vtu_2d_path = Path("images/fracture_flow_2.vtu")
+vtu_image_2d = darsia.imread(
+    vtu_2d_path, key="c", shape=(200, 200), origin=[0, 0], vtu_dim=2
+)
+
+# Read one-dimensional vtu image (two-dimensional reconstruction
+# through conservative embedding)
+vtu_1d_path = Path("images/fracture_flow_1.vtu")
+fracture_aperture = 0.1 * 0.01  # in m
+vtu_image_1d = darsia.imread(
+    vtu_1d_path,
+    key="c",
+    shape=(1001, 51),
+    origin=[0, 0],
+    vtu_dim=1,
+    width=fracture_aperture,
+)
+
+# Equidimensional reconstrctions. Superpose 2d and 1d images.
+porosity_2d = 0.211
+porosity_1d = 1.0
+vtu_image = darsia.superpose(
+    [darsia.weight(vtu_image_2d, porosity_2d), darsia.weight(vtu_image_1d, porosity_1d)]
+)
+vtu_image.show("equi-dimensionsional reconstruction")

--- a/src/darsia/__init__.py
+++ b/src/darsia/__init__.py
@@ -9,6 +9,7 @@ from darsia.image.indexing import *
 from darsia.image.patches import *
 from darsia.image.subregions import *
 from darsia.image.imread import *
+from darsia.image.arithmetics import *
 from darsia.mathematics.derivatives import *
 from darsia.mathematics.stoppingcriterion import *
 from darsia.mathematics.solvers import *

--- a/src/darsia/image/arithmetics.py
+++ b/src/darsia/image/arithmetics.py
@@ -122,7 +122,7 @@ def superpose(images: list[darsia.Image]) -> darsia.Image:
         "dimensions": dimensions,
         "origin": origin,
         "series": series,
-        # "date": date,
+        "date": date,
         "time": time,
     }
 

--- a/src/darsia/image/arithmetics.py
+++ b/src/darsia/image/arithmetics.py
@@ -1,0 +1,187 @@
+"""Utils for non-standard arithmetics of images,
+as weighted superposition.
+
+"""
+
+from typing import Union
+
+import cv2
+import numpy as np
+
+import darsia
+
+
+def weight(img: darsia.Image, weight: Union[float, int, darsia.Image]) -> darsia.Image:
+    """Scalar or element-wise weight of images.
+
+    Args:
+        img (darsia.Image): image.
+        weight (float or Image): weight, either constant, or heterogeneous provided through
+            an image with local coordinates (need to be the same as for the input image).
+
+    Returns:
+        Image: weighted image.
+
+    """
+    weighted_img = img.copy()
+    if isinstance(weight, float) or isinstance(weight, int):
+        weighted_img.img *= weight
+    elif isinstance(weight, darsia.Image):
+        # TODO add safety check whether the coordinate systems are the same
+        space_dim = img.space_dim
+        assert np.isclose(img.origin, weight.origin)
+        assert np.isclose(img.dimensions, weight.dimensions)
+        assert len(weight.img.shape) == space_dim
+
+        # Reshape if needed.
+        if img.img.shape[:space_dim] != weight.img.shape[:space_dim]:
+            if img.space_dim == 2:
+                weight.img = cv2.resize(
+                    weight.img,
+                    tuple(reversed(img.img.shape[:2])),
+                    interpolation=cv2.INTER_LINEAR,
+                )
+            else:
+                raise NotImplementedError
+
+        # Rescale
+        weighted_img.img = np.mulitply(weighted_img.img, weight.img)
+
+    return weighted_img
+
+
+def superpose(images: list[darsia.Image]) -> darsia.Image:
+    """Superposition of images with possibly incompatible coordinatesystems.
+
+    Args:
+        images (list of images): images
+
+    Returns:
+        Image: superposed image.
+
+    """
+    # ! ---- Commonalities.
+
+    # Safety checks
+    assert all([img.space_dim == images[0].space_dim for img in images])
+    assert all([img.indexing == images[0].indexing for img in images])
+    assert all([img.series == images[0].series for img in images])
+    assert all([isinstance(img, type(images[0])) for img in images])
+    assert all([img.original_dtype == images[0].original_dtype for img in images])
+
+    # TODO include time, for now assume it is the same...
+    # print([img.date for img in images])
+
+    # Fetch common specs
+    # TODO use meta and update? fetch from images[0]
+    space_dim = images[0].space_dim
+    indexing = images[0].indexing
+    series = images[0].series
+
+    # TODO double check
+    date = images[0].date
+    time = images[0].time
+
+    # TODO make the following two part of metadata? better not...
+    # they are directly encoded in Image and array...
+    dtype = images[0].original_dtype
+    ImageType = type(images[0])
+
+    # ! ---- Determine the meta data
+
+    # Determine the common origin and opposite corner (as Cartesian coordinates)
+    collection_origin = np.vstack(tuple(img.origin for img in images))
+    collection_opposite_corner = np.vstack(tuple(img.opposite_corner for img in images))
+    origin = []
+    opposite_corner = []
+    for i in range(space_dim):
+        # In case the axis follows a different orientation than
+        # the corresponding cartesian axis, the maximal coordinate
+        # has to be chosen (e.g., y-axis in 2d), minimal otherwise.
+        _, revert = darsia.interpret_indexing("xyz"[i], indexing)
+        if revert:
+            origin.append(np.max(collection_origin[:, i]))
+            opposite_corner.append(np.min(collection_opposite_corner[:, i]))
+        else:
+            origin.append(np.min(collection_origin[:, i]))
+            opposite_corner.append(np.max(collection_opposite_corner[:, i]))
+
+    # Determine resulting dimensions in matrix indexing
+    cartesian_dimensions = [
+        abs(opposite_corner[i] - origin[i]) for i in range(space_dim)
+    ]
+    to_matrix_indexing = [
+        darsia.interpret_indexing("ijk"[i], "xyz"[:space_dim])[0]
+        for i in range(space_dim)
+    ]
+    dimensions = [cartesian_dimensions[i] for i in to_matrix_indexing]
+
+    meta = {
+        "dim": space_dim,
+        "indexing": indexing,
+        "dimensions": dimensions,
+        "origin": origin,
+        "series": series,
+        # "date": date,
+        "time": time,
+    }
+
+    # ! ---- Superpose the data
+
+    # Find the correct shape and initialize image, and coordinatesystem
+    collection_voxel_size = np.vstack(tuple(img.voxel_size for img in images))
+    voxel_size = np.min(collection_voxel_size, axis=0)
+    shape = tuple(
+        np.ceil(dimensions[i] / voxel_size[i]).astype(int) for i in range(space_dim)
+    )
+    img_arr = np.zeros(shape, dtype=dtype)
+    image = ImageType(img=img_arr, **meta)
+
+    # Successively add images to the right voxels - essentially use resample
+    # Approach from imread_from_vtu, but now voxel grids are provided.
+    for img in images:
+        # Get array and shape
+        array = img.img
+        rows, cols = array.shape
+
+        # Use corners as pts_src
+        pts_src = np.array(
+            [
+                [0, 0],
+                [rows, 0],
+                [rows, cols],
+                [0, cols],
+            ]
+        )
+
+        # Get origin and opposite corner for img
+        origin = img.origin
+        opposite_corner = img.opposite_corner
+
+        # Use image.coordinatesystem to retrieve pts_dst
+        mapped_voxel_origin = image.coordinatesystem.voxel(origin)
+        mapped_voxel_opposite_corner = image.coordinatesystem.voxel(opposite_corner)
+
+        pts_dst = np.array(
+            [
+                [mapped_voxel_origin[0], mapped_voxel_origin[1]],
+                [mapped_voxel_opposite_corner[0], mapped_voxel_origin[1]],
+                [mapped_voxel_opposite_corner[0], mapped_voxel_opposite_corner[1]],
+                [mapped_voxel_origin[0], mapped_voxel_opposite_corner[1]],
+            ]
+        )
+
+        # Warp array
+        warped_array = darsia.extract_quadrilateral_ROI(
+            img_src=array,
+            pts_src=pts_src,
+            pts_dst=pts_dst,
+            indexing="matrix",
+            interpolation="inter_area",
+            shape=shape,
+        )
+
+        # Add warped_array to image.img
+        image.img += warped_array
+
+    return image

--- a/src/darsia/image/image.py
+++ b/src/darsia/image/image.py
@@ -204,7 +204,7 @@ class Image:
         self.opposite_corner = self.coordinatesystem.coordinate(
             self.shape[: self.space_dim]
         )
-        """Cartesian coordinate of the corner opposite to orgin."""
+        """Cartesian coordinate of the corner opposite to origin."""
 
         # ! ---- Safety check on dimensionality and resolution of image.
         assert len(self.shape) == self.space_dim + self.time_dim + self.range_dim

--- a/src/darsia/image/imread.py
+++ b/src/darsia/image/imread.py
@@ -652,13 +652,13 @@ def _embed_data(
     # Provide a point cloud effectively lying on the higher-dimensional
     # representation of the lower-dimensional object.
     points_lower = np.vstack(
-        (
+        tuple(
             points[cells[:, i]] - 0.5 * width * unit_normals
             for i in range(num_points_per_cell)
         )
     )
     points_upper = np.vstack(
-        (
+        tuple(
             points[cells[:, i]] + 0.5 * width * unit_normals
             for i in range(num_points_per_cell)
         )

--- a/src/darsia/image/subregions.py
+++ b/src/darsia/image/subregions.py
@@ -2,11 +2,54 @@
 Module containing auxiliary methods to extract ROIs from darsia Images.
 """
 
+from typing import Literal
+
 import cv2
 import numpy as np
 
+IndexingOption = Literal["matrix", "reverse matrix"]
+"""Indexing option consi    else:dered in the following conversion."""
 
-def extract_quadrilateral_ROI(img_src: np.ndarray, **kwargs) -> np.ndarray:
+
+def to_reverse_matrix_indexing(
+    pixel: np.ndarray, indexing: IndexingOption = "reverse matrix"
+) -> np.ndarray:
+    """Convert pixel coordinates to reverse matrix indexing format.
+
+    Args:
+        pixel (np.ndarray): pixel coordinates
+        indexing (IndexingOption): indexing of pixel
+
+    Returns:
+        pixel converted to 'reverse matrix' indexing
+
+    Raises:
+        NotImplementedError: if dimension not 2
+        NotImplementedError: if indexing not among IndexingOption
+
+    """
+    if not len(pixel.shape) == 2:
+        raise NotImplementedError
+
+    if indexing == "reverse matrix":
+        return pixel
+    elif indexing == "matrix":
+        return np.fliplr(np.atleast_2d(pixel))
+    else:
+        raise NotImplementedError
+
+
+InterpolationOption = Literal["inter_nearest", "inter_linear", "inter_area"]
+"""Interpolation options considered in below warp."""
+
+
+def extract_quadrilateral_ROI(
+    img_src: np.ndarray,
+    pts_src,
+    indexing: IndexingOption = "reverse matrix",
+    interpolation: InterpolationOption = "inter_linear",
+    **kwargs
+) -> np.ndarray:
     """
     Extract quadrilateral ROI using a perspective transform,
     given known corner points of a square (default) object.
@@ -15,52 +58,76 @@ def extract_quadrilateral_ROI(img_src: np.ndarray, **kwargs) -> np.ndarray:
         kwargs (optional keyword arguments):
             width (int or float): width of the physical object
             height (int or float): height of the physical object
-            pts_src (array): N points with pixels in (col,row) format, N>=4
+            pts_src (array): N points with pixel coordinates in (col,row) format, N>=4
             pts_dst (array, optional): N points with pixels in (col, row) format, N>=4
     """
 
-    # Determine original and target size
-    height, width = img_src.shape[:2]
-    target_width = kwargs.get("width", width)
-    target_height = kwargs.get("height", height)
+    # FIXME: Implementation hardcoded for 2d.
+
+    # ! ---- Properties of image
+
+    scalar = len(img_src.shape) == 2
+
+    # ! ---- Size of new image
+
+    # Determine current dimensions and use as default size.
+    original_shape = img_src.shape[:2]
+
+    if "width" in kwargs and "height" in kwargs:
+        # Determine target image dimensions based on physical units.
+        target_width = kwargs.get("width")
+        target_height = kwargs.get("height")
+
+        # Aim at comparably many pixels as in the provided
+        # image, modulo the ratio.
+        aspect_ratio = target_width / target_height
+
+        # Try to keep this aspect ratio, but do not use more pixels than before.
+        # Convert to number of pixels
+        original_height, original_width = original_shape
+        width = min(original_width, int(aspect_ratio * float(original_height)))
+        height = min(original_height, int(1.0 / aspect_ratio * float(original_width)))
+
+    else:
+        # Determine target image dimensions based on voxel numbers.
+        target_shape = kwargs.get("shape", original_shape)
+        height, width = target_shape
+
+    # ! ---- Mapping
 
     # Fetch corner points in the provided image
-    pts_src = kwargs.get("pts_src")
     if isinstance(pts_src, list):
         pts_src = np.array(pts_src)
-
-    # Aim at comparably many pixels as in the provided
-    # image, modulo the ratio.
-    aspect_ratio = target_width / target_height
-
-    # Try to keep this aspect ratio, but do not use more pixels than before.
-    # Convert to number of pixels
-    target_width = min(width, int(aspect_ratio * float(height)))
-    target_height = min(height, int(1.0 / aspect_ratio * float(width)))
+    pts_src = to_reverse_matrix_indexing(pts_src, indexing)
 
     # Assign corner points as destination points if none are provided.
-    if "pts_dst" not in kwargs:
+    if "pts_dst" in kwargs:
+
+        pts_dst: np.ndarray = to_reverse_matrix_indexing(
+            np.array(kwargs.get("pts_dst")), indexing
+        )
+
+    else:
+
         # Assume implicitly that corner points have been provided,
         # and that their orientation is mathematically positive,
         # starting with the top left corner.
-        # Further more use reversed matrix indexing, i.e., (col,row).
-        assert pts_src.shape[0] == 4
+        # Furthermore, use reverse matrix indexing, i.e., (col,row).
         pts_dst = np.array(
             [
                 [0, 0],
-                [0, target_height - 1],
-                [target_width - 1, target_height - 1],
-                [target_width - 1, 0],
+                [0, height - 1],
+                [width - 1, height - 1],
+                [width - 1, 0],
             ]
         )
-    else:
-        pts_dst = kwargs.get("pts_dst")
-        if isinstance(pts_dst, list):
-            pts_dst = np.array(pts_dst)
 
+    assert pts_src.shape[0] == pts_dst.shape[0]
     P = cv2.getPerspectiveTransform(
         pts_src.astype(np.float32), pts_dst.astype(np.float32)
     )
+
+    # ! ---- Warp image
 
     # Take care of data type - cv2 requires np.float32 objects.
     # However, when using input images with integer dtype, it is
@@ -70,15 +137,29 @@ def extract_quadrilateral_ROI(img_src: np.ndarray, **kwargs) -> np.ndarray:
     # routine returns arrays of same dtype again.
     dtype = img_src.dtype
 
+    interpolation_flag = None
+    if interpolation == "inter_nearest":
+        interpolation_flag = cv2.INTER_NEAREST
+    elif interpolation == "inter_linear":
+        interpolation_flag = cv2.INTER_LINEAR
+    elif interpolation == "inter_area":
+        interpolation_flag == cv2.INTER_AREA
+    else:
+        raise NotImplementedError
+
     # Warp source image. Warping may convert a 3-tensor to a 2-tensor.
     # Force to use a 3-tensor structure.
     img_dst = np.atleast_3d(
         cv2.warpPerspective(
             img_src.astype(np.float32),
             P,
-            (target_width, target_height),
-            flags=cv2.INTER_LINEAR,
+            (width, height),
+            flags=interpolation_flag,
         )
     ).astype(dtype)
+
+    # Reduce to scalar image array, if input provided in such format.
+    if scalar:
+        img_dst = img_dst[:, :, 0]
 
     return img_dst

--- a/tests/integration/test_examples.py
+++ b/tests/integration/test_examples.py
@@ -42,13 +42,25 @@ def test_imread():
     #            f'python {str(Path(f"{os.path.dirname(__file__)}/../../examples/dicom_images.py"))}'
     #        )
     #    )
-    #    assert not (
-    #        os.system(
-    #            f'python {str(Path(f"{os.path.dirname(__file__)}/../../examples/vtu_images.py"))}'
-    #        )
-    #    )
     assert not (
         os.system(
             f'python {str(Path(f"{os.path.dirname(__file__)}/../../examples/reading_images.py"))}'
+        )
+    )
+
+
+def test_imread_vtu_images():
+
+    # Test whether images required for test are available
+    folder = Path("../../examples/images")
+    images_exist = len(list(sorted(folder.glob("fracture_flow*.vtu")))) == 2
+
+    if not images_exist:
+        pytest.xfail("Images required for test not available.")
+
+    # If so, run test.
+    assert not (
+        os.system(
+            f'python {str(Path(f"{os.path.dirname(__file__)}/../../examples/vtu_images.py"))}'
         )
     )

--- a/tests/integration/test_examples.py
+++ b/tests/integration/test_examples.py
@@ -1,6 +1,8 @@
 import os
 from pathlib import Path
 
+import pytest
+
 
 def test_color_correction():
     assert not (


### PR DESCRIPTION
Mixed-dimensional images need to be voxelized (reconstructed) for conventional image analysis. Add capabilities to reconstruct mixed-dimensional images, e.g., fracture flow provided as vtu images (example is added).