### PR TITLE
Vtu images transformations

### DIFF
--- a/examples/co2_and_tracer_analysis.py
+++ b/examples/co2_and_tracer_analysis.py
@@ -41,16 +41,14 @@ co2_array = cv2.cvtColor(cv2.imread(image_folder + "co2_2.jpg"), cv2.COLOR_BGR2R
 baseline_co2 = darsia.Image(
     base_array,
     transformations=[color_correction, curvature_correction],
-    width = 2.8,
-    height = 1.5,
-    origin=[0.0, 1.5],
+    width=2.8,
+    height=1.5,
 )
 co2_image = darsia.Image(
     co2_array,
     transformations=[color_correction, curvature_correction],
-    width = 2.8,
-    height = 1.5,
-    origin=[0.0, 1.5],
+    width=2.8,
+    height=1.5,
 )
 
 # Construct concentration analysis for detecting the co2 concentration
@@ -105,16 +103,14 @@ tracer_array = cv2.cvtColor(
 baseline_tracer = darsia.Image(
     base_tracer_array,
     transformations=[color_correction, curvature_correction],
-    width = 2.8,
-    height = 1.5,
-    origin=[0.0, 1.5],
+    width=2.8,
+    height=1.5,
 )
 tracer_image = darsia.Image(
     tracer_array,
     transformations=[color_correction, curvature_correction],
-    width = 2.8,
-    height = 1.5,
-    origin=[0.0, 1.5],
+    width=2.8,
+    height=1.5,
 )
 
 # Define restoration routine

--- a/examples/color_correction.py
+++ b/examples/color_correction.py
@@ -14,7 +14,9 @@ image = f"{os.path.dirname(__file__)}/images/baseline.jpg"
 # Create an uncorrected image for comparison
 image_array = cv2.cvtColor(cv2.imread(image), cv2.COLOR_BGR2RGB)
 uncorrected_baseline = darsia.Image(
-    image_array, width=2.8, height=1.5, origin=[0, 1.5]
+    image_array,
+    width=2.8,
+    height=1.5,
 )
 
 # ! ---- Setup the machine learning based color correction
@@ -35,7 +37,6 @@ experimental_corrected_baseline = darsia.Image(
     transformations=[experimental_color_correction],
     width=2.8,
     height=1.5,
-    origin=[0.0, 1.5],
 )
 
 # ! ---- Setup the manual color correction
@@ -68,7 +69,6 @@ corrected_baseline = darsia.Image(
     transformations=[color_correction],
     width=2.8,
     height=1.5,
-    origin=[0.0, 1.5],
 )
 
 # -------- Plot corrected and uncorrected images

--- a/examples/image_registration.py
+++ b/examples/image_registration.py
@@ -54,7 +54,6 @@ img_src = darsia.Image(
     ],
     width=2.8,
     height=1.5,
-    origin=[0.0, 1.5],
 )
 
 img_dst = darsia.Image(
@@ -65,7 +64,6 @@ img_dst = darsia.Image(
     ],
     width=2.8,
     height=1.5,
-    origin=[0.0, 1.5],
 )
 
 plt.figure("src")

--- a/examples/reading_images.py
+++ b/examples/reading_images.py
@@ -25,7 +25,6 @@ optical_paths = [
 
 optical_metadata = {
     "dimensions": [1.5, 2.8],
-    "origin": [0.0, 1.5],
 }
 
 # ! ---- Corrections
@@ -42,7 +41,9 @@ curvature_correction = darsia.CurvatureCorrection(config=config["curvature"])
 single_optical_image = darsia.imread(
     optical_paths[0], transformations=[curvature_correction], **optical_metadata
 )
-single_optical_image.show(f"single image - {single_optical_image.time} - {single_optical_image.date}", 5)
+single_optical_image.show(
+    f"single image - {single_optical_image.time} - {single_optical_image.date}", 5
+)
 
 # Space-time image
 spacetime_optical_image = darsia.imread_from_optical(
@@ -57,7 +58,10 @@ for time_index in range(spacetime_optical_image.time_num):
     spacetime_slice: darsia.OpticalImage = spacetime_optical_image.time_slice(
         time_index
     )
-    spacetime_slice.show(f"slice {time_index} in space time image - {spacetime_slice.time} - {spacetime_slice.date}", 5)
+    spacetime_slice.show(
+        f"slice {time_index} in space time image - {spacetime_slice.time} - {spacetime_slice.date}",
+        5,
+    )
 
 # Change color for an entire image.
 spacetime_optical_image.to_trichromatic("hsv")

--- a/examples/vtu_images.py
+++ b/examples/vtu_images.py
@@ -10,9 +10,7 @@ import darsia
 
 # Read two-dimensional vtu image (standard)
 vtu_2d_path = Path("images/fracture_flow_2.vtu")
-vtu_image_2d = darsia.imread(
-    vtu_2d_path, key="c", shape=(200, 200), origin=[0, 0], vtu_dim=2
-)
+vtu_image_2d = darsia.imread(vtu_2d_path, key="c", shape=(200, 200), vtu_dim=2)
 
 # Read one-dimensional vtu image (two-dimensional reconstruction
 # through conservative embedding)
@@ -22,7 +20,6 @@ vtu_image_1d = darsia.imread(
     vtu_1d_path,
     key="c",
     shape=(1001, 51),
-    origin=[0, 0],
     vtu_dim=1,
     width=fracture_aperture,
 )

--- a/src/darsia/image/arithmetics.py
+++ b/src/darsia/image/arithmetics.py
@@ -32,10 +32,9 @@ def weight(img: darsia.Image, weight: Union[float, int, darsia.Image]) -> darsia
         weighted_img.img *= weight
 
     elif isinstance(weight, darsia.Image):
-        # TODO add safety check whether the coordinate systems are the same
+        assert np.allclose(img.origin, weight.origin)
+        assert np.allclose(img.dimensions, weight.dimensions)
         space_dim = img.space_dim
-        assert np.isclose(img.origin, weight.origin)
-        assert np.isclose(img.dimensions, weight.dimensions)
         assert len(weight.img.shape) == space_dim
 
         # Reshape if needed.
@@ -50,7 +49,10 @@ def weight(img: darsia.Image, weight: Union[float, int, darsia.Image]) -> darsia
                 raise NotImplementedError
 
         # Rescale
-        weighted_img.img = np.mulitply(weighted_img.img, weight.img)
+        weighted_img.img = np.multiply(weighted_img.img, weight.img)
+
+    else:
+        raise ValueError
 
     return weighted_img
 

--- a/src/darsia/image/arithmetics.py
+++ b/src/darsia/image/arithmetics.py
@@ -22,10 +22,15 @@ def weight(img: darsia.Image, weight: Union[float, int, darsia.Image]) -> darsia
     Returns:
         Image: weighted image.
 
+    Raises:
+        NotImplementedError: if the weight has incompatible size and the images are 3d.
+        ValueError: if the weight is of unsopported type
+
     """
     weighted_img = img.copy()
     if isinstance(weight, float) or isinstance(weight, int):
         weighted_img.img *= weight
+
     elif isinstance(weight, darsia.Image):
         # TODO add safety check whether the coordinate systems are the same
         space_dim = img.space_dim
@@ -59,6 +64,9 @@ def superpose(images: list[darsia.Image]) -> darsia.Image:
     Returns:
         Image: superposed image.
 
+    Raises:
+        NotImplementedError: If dimension of images is not 2.
+
     """
     # ! ---- Commonalities.
 
@@ -81,6 +89,9 @@ def superpose(images: list[darsia.Image]) -> darsia.Image:
     indexing = images[0].indexing
     series = images[0].series
     scalar = images[0].scalar
+
+    if not space_dim == 2:
+        raise NotImplementedError
 
     # TODO double check
     date = images[0].date

--- a/src/darsia/image/arithmetics.py
+++ b/src/darsia/image/arithmetics.py
@@ -154,6 +154,8 @@ def superpose(images: list[darsia.Image]) -> darsia.Image:
     )
     if series:
         shape = *space_shape, time_num
+    else:
+        shape = space_shape
     if not scalar:
         raise NotImplementedError("Need to extend shape")
     img_arr = np.zeros(shape, dtype=dtype)

--- a/src/darsia/image/image.py
+++ b/src/darsia/image/image.py
@@ -277,13 +277,13 @@ class Image:
 
         assert self.space_dim == image.space_dim
         assert self.scalar == image.scalar
-        assert np.all(np.isclose(np.array(self.num_voxels), np.array(image.num_voxels)))
+        assert np.allclose(np.array(self.num_voxels), np.array(image.num_voxels))
         if not self._is_none(self.date) and not self._is_none(image.date):
             self_last_date = self.date[-1] if self.series else self.date
             image_first_date = image.date[0] if image.series else image.date
             assert self_last_date < image_first_date
-        assert np.all(np.isclose(np.array(self.dimensions), np.array(image.dimensions)))
-        assert np.all(np.isclose(np.array(self.origin), np.array(image.origin)))
+        assert np.allclose(np.array(self.dimensions), np.array(image.dimensions))
+        assert np.allclose(self.origin, image.origin)
 
         # ! ---- Update data
 

--- a/src/darsia/image/image.py
+++ b/src/darsia/image/image.py
@@ -75,8 +75,13 @@ class Image:
 
         # ! ---- Cache data
         self.img = img
-        self.shape = img.shape
+        """Data array."""
+
+        self.shape = img.shape  # TODO - not attribute of self.
+        """Shape of the image."""
+
         self.original_dtype = img.dtype
+        """Original dtype at construction of the object."""
 
         # ! ---- Spatial meta information
         self.space_dim: int = kwargs.get("dim", 2)

--- a/src/darsia/image/image.py
+++ b/src/darsia/image/image.py
@@ -90,7 +90,7 @@ class Image:
         self.space_num: int = np.prod(self.shape[: self.space_dim])
         """Spatial resolution, i.e., number of voxels."""
 
-        self.indexing = kwargs.get("indexing", "ij")
+        self.indexing = kwargs.get("indexing", "ijk"[: self.space_dim])
         """Indexing of each axis in context of matrix indexing (ijk)
         or Cartesian coordinates (xyz)."""
 

--- a/src/darsia/image/image.py
+++ b/src/darsia/image/image.py
@@ -108,7 +108,7 @@ class Image:
         if "width" in kwargs:
             self.dimensions[1] = kwargs.get("width")
         if "depth" in kwargs:
-            self.dimenions[2] = kwargs.get("depth")
+            self.dimensions[2] = kwargs.get("depth")
 
         self.num_voxels: int = self.img.shape[: self.space_dim]
         """Number of voxels in each dimension."""

--- a/src/darsia/image/image.py
+++ b/src/darsia/image/image.py
@@ -118,7 +118,13 @@ class Image:
         ]
         """Size of each voxel in each direction, ordered as indexing."""
 
-        default_origin = [0, self.dimensions[0]]
+        default_origin = self.space_dim * [0]
+        for index_counter, index in enumerate(self.indexing):
+            axis, reverse_axis = darsia.interpret_indexing(
+                index, "xyz"[: self.space_dim]
+            )
+            if reverse_axis:
+                default_origin[axis] = self.dimensions[index_counter]
         self.origin = np.array(kwargs.pop("origin", default_origin))
         """Cartesian coordinates associated to the [0,0,0] voxel (after
         applying transformations), using Cartesian indexing."""

--- a/src/darsia/image/image.py
+++ b/src/darsia/image/image.py
@@ -710,13 +710,13 @@ class ScalarImage(Image):
         }
         kwargs.pop("scalar", None)
 
+        self.name = kwargs.get("name", None)
+        """Name of image, e.g., used to describe the origin."""
+
         # Construct a general image with the specs of an optical image
         super().__init__(img, transformations, **scalar_metadata, **kwargs)
 
         assert self.range_dim == 0
-
-        self.name = kwargs.get("name", None)
-        """Name of image, e.g., used to describe the origin."""
 
     def copy(self) -> ScalarImage:
         """Copy constructor.

--- a/src/darsia/image/imread.py
+++ b/src/darsia/image/imread.py
@@ -158,6 +158,7 @@ def imread_from_optical(
 
         # Fix metadata
         kwargs["series"] = True
+        kwargs["color_space"] = "RGB"
 
         # Define image
         image = darsia.OpticalImage(

--- a/tests/unit/test_arithmetics.py
+++ b/tests/unit/test_arithmetics.py
@@ -9,8 +9,7 @@ import darsia
 
 def test_scalar_weight_3d():
 
-    array = np.ones((3, 4, 5), dtype=float)
-    image = darsia.Image(array, dim=3)
+    image = darsia.Image(np.ones((3, 4, 5), dtype=float), dim=3)
     weight = 2.0
     weighted_image = darsia.weight(image, weight)
     assert np.allclose(weighted_image.img, 2 * np.ones((3, 4, 5)))
@@ -39,3 +38,12 @@ def test_array_weight_3d():
     weight = darsia.Image(np.random.rand(3, 4, 5), dim=3)
     weighted_image = darsia.weight(image, weight)
     assert np.allclose(weighted_image.img, weight.img)
+
+
+def test_superposition_2d():
+
+    image1 = darsia.ScalarImage(np.ones((3, 4), dtype=float), dim=2)
+    image2 = darsia.ScalarImage(2 * np.ones((3, 4), dtype=float), dim=2)
+    image3 = darsia.ScalarImage(3 * np.ones((3, 4), dtype=float), dim=2)
+    superposed_image = darsia.superpose([image1, image2, image3])
+    assert np.allclose(superposed_image.img, 6 * np.ones((3, 4)))

--- a/tests/unit/test_arithmetics.py
+++ b/tests/unit/test_arithmetics.py
@@ -47,3 +47,21 @@ def test_superposition_2d():
     image3 = darsia.ScalarImage(3 * np.ones((3, 4), dtype=float), dim=2)
     superposed_image = darsia.superpose([image1, image2, image3])
     assert np.allclose(superposed_image.img, 6 * np.ones((3, 4)))
+
+
+def test_superposition_2d_spacetime():
+
+    meta = {
+        "dim": 2,
+        "series": True,
+        "time": [0, 1, 2, 3, 4],
+    }
+    image1 = darsia.ScalarImage(np.ones((3, 4, 5), dtype=float), **meta)
+    image2 = darsia.ScalarImage(2 * np.ones((3, 4, 5), dtype=float), **meta)
+    image3 = darsia.ScalarImage(3 * np.ones((3, 4, 5), dtype=float), **meta)
+    superposed_image = darsia.superpose([image1, image2, image3])
+
+    assert np.allclose(superposed_image.img, 6 * np.ones((3, 4, 5)))
+    superposed_meta = superposed_image.metadata()
+    for key, value in meta.items():
+        assert np.allclose(value, superposed_meta[key])

--- a/tests/unit/test_arithmetics.py
+++ b/tests/unit/test_arithmetics.py
@@ -1,0 +1,41 @@
+"""Module testing the arithmetics capabilities for images.
+
+"""
+
+import numpy as np
+
+import darsia
+
+
+def test_scalar_weight_3d():
+
+    array = np.ones((3, 4, 5), dtype=float)
+    image = darsia.Image(array, dim=3)
+    weight = 2.0
+    weighted_image = darsia.weight(image, weight)
+    assert np.allclose(weighted_image.img, 2 * np.ones((3, 4, 5)))
+
+
+def test_array_weight_2d():
+
+    image = darsia.Image(np.ones((3, 4), dtype=float), dim=2)
+    weight = darsia.Image(np.random.rand(3, 4), dim=2)
+    weighted_image = darsia.weight(image, weight)
+    assert np.allclose(weighted_image.img, weight.img)
+
+
+def test_incompatible_weight_2d():
+
+    image = darsia.Image(np.ones((6, 8), dtype=float), dim=2)
+    weight = darsia.Image(2 * np.ones((3, 4)), dim=2)
+
+    weighted_image = darsia.weight(image, weight)
+    assert np.allclose(weighted_image.img, 2 * np.ones((6, 8)))
+
+
+def test_array_weight_3d():
+
+    image = darsia.Image(np.ones((3, 4, 5), dtype=float), dim=3)
+    weight = darsia.Image(np.random.rand(3, 4, 5), dim=3)
+    weighted_image = darsia.weight(image, weight)
+    assert np.allclose(weighted_image.img, weight.img)

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -43,7 +43,6 @@ def test_initialize_general_image():
         "dim": 2,
         "indexing": "ij",
         "dimensions": [1.5, 2.8],
-        "origin": [0.0, 1.5],
     }
 
     # ! ---- Initialize darsia image
@@ -76,13 +75,11 @@ def test_initialize_optical_image():
         "dim": 2,
         "indexing": "ij",
         "dimensions": [1.5, 2.8],
-        "origin": [0.0, 1.5],
     }
 
     optical_info = {
         "series": False,
         "dimensions": [1.5, 2.8],
-        "origin": [0.0, 1.5],
     }
 
     # ! ---- Initialize darsia image
@@ -114,7 +111,6 @@ def test_monochromatic_optical_images():
     optical_info = {
         "series": False,
         "dimensions": [1.5, 2.8],
-        "origin": [0.0, 1.5],
     }
 
     # ! ---- Initialize darsia image

--- a/tests/unit/test_image_registration.py
+++ b/tests/unit/test_image_registration.py
@@ -79,7 +79,6 @@ def test_image_registration():
             curvature_correction,
         ],
         dimensions=[1.5, 2.8],
-        origin=[0.0, 1.5],
     )
 
     img_dst = darsia.Image(
@@ -89,7 +88,6 @@ def test_image_registration():
             curvature_correction,
         ],
         dimensions=[1.5, 2.8],
-        origin=[0.0, 1.5],
     )
 
     # Extract ROI to cut away the color palette. Use pixel ranges to crop the image.

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -3,11 +3,14 @@
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 import darsia
 
 
 def test_imread_from_numpy():
+    """Test imread for numpy images."""
+
     # Generate Image from random array
     shape = (10, 20)
     array = np.random.rand(*shape)
@@ -22,3 +25,35 @@ def test_imread_from_numpy():
 
     # Clean up
     path.unlink()
+
+
+def test_imread_from_vtu():
+    """Test imread for single and space-time vtu files."""
+
+    vtu_2d_path = Path("../../examples/images/fracture_flow_2.vtu")
+    if not vtu_2d_path.exists():
+        pytest.xfail("Image required for test not available.")
+
+    # Single time-slab
+    vtu_image_2d = darsia.imread(vtu_2d_path, key="c", shape=(200, 200), vtu_dim=2)
+
+    # Space-time image
+    space_time_vtu_image_2d = darsia.imread(
+        [vtu_2d_path, vtu_2d_path], time=[0, 1], key="c", shape=(200, 200), vtu_dim=2
+    )
+
+    # Compare
+    assert space_time_vtu_image_2d.time_num == 2
+    assert np.allclose(vtu_image_2d.origin, space_time_vtu_image_2d.origin)
+    assert np.allclose(vtu_image_2d.dimensions, space_time_vtu_image_2d.dimensions)
+    assert not vtu_image_2d.series
+    assert space_time_vtu_image_2d.series
+
+    slice_0 = space_time_vtu_image_2d.time_slice(0)
+    slice_1 = space_time_vtu_image_2d.time_slice(1)
+    assert not slice_0.series
+    assert np.allclose(slice_0.origin, vtu_image_2d.origin)
+    assert np.allclose(slice_0.dimensions, vtu_image_2d.dimensions)
+
+    assert np.allclose(slice_0.img, vtu_image_2d.img)
+    assert np.allclose(slice_1.img, vtu_image_2d.img)


### PR DESCRIPTION
Several smaller extensions, useful for vtu images:
- imread for space-time vtu images [tested]
- superposition of space-time images [tested]

General maintanence:
- default origin (convention introduced based on flipped axis) [tested]
- other small changes