### PR TITLE
Generalize concentration analysis, using default arguments

### DIFF
--- a/src/darsia/multi_image_analysis/concentrationanalysis.py
+++ b/src/darsia/multi_image_analysis/concentrationanalysis.py
@@ -65,11 +65,13 @@ class ConcentrationAnalysis:
 
         self.base: Optional[darsia.Image] = None
         """Baseline image."""
+        self._base_collection: list[darsia.Image] = []
+        """Collection of baseline images."""
         if base is not None:
             if not isinstance(base, list):
                 base = [base]
             self.base = base[0].copy()
-            # FIXME
+            self._base_collection = base
             if self.base.space_dim != 2:
                 raise NotImplementedError
 
@@ -148,7 +150,7 @@ class ConcentrationAnalysis:
         if baseline_images is None and self.base is not None:
 
             # Use internal baseline images, if available.
-            baseline_images = self.base[1:]
+            baseline_images = self._base_collection[1:]
 
         self.threshold_cleaning_filter = None
         """Cleaning filter."""

--- a/src/darsia/multi_image_analysis/concentrationanalysis.py
+++ b/src/darsia/multi_image_analysis/concentrationanalysis.py
@@ -321,9 +321,9 @@ class ConcentrationAnalysis:
         else:
 
             if self._diff_option == "positive":
-                diff = np.clip(img.img - reference, 0, None)
+                diff = np.clip(img.img - self.base.img, 0, None)
             elif self._diff_option == "negative":
-                diff = np.clip(reference - img.img, 0, None)
+                diff = np.clip(self.base.img - img.img, 0, None)
             elif self._diff_option == "absolute":
                 diff = skimage.util.compare_images(
                     img.img, self.base.img, method="diff"

--- a/src/darsia/multi_image_analysis/concentrationanalysis.py
+++ b/src/darsia/multi_image_analysis/concentrationanalysis.py
@@ -1,6 +1,7 @@
 """
 Module that contains a class which provides the capabilities to
 analyze concentrations/saturation profiles based on image comparison.
+
 """
 
 import copy
@@ -27,11 +28,13 @@ class ConcentrationAnalysis:
 
     def __init__(
         self,
-        base: Union[
-            darsia.Image,
-            list[darsia.Image],
+        base: Optional[
+            Union[
+                darsia.Image,
+                list[darsia.Image],
+            ]
         ],
-        signal_reduction: darsia.SignalReduction,
+        signal_reduction: darsia.SignalReduction = None,
         balancing: Optional[darsia.Model] = None,
         restoration: Optional[darsia.TVD] = None,
         model: darsia.Model = darsia.Identity,
@@ -44,25 +47,31 @@ class ConcentrationAnalysis:
         Args:
             base (Image or list of such): baseline image(s); if multiple provided,
                 these are used to define a cleaning filter.
-            signal_reduction (darsia.SignalReduction): reduction from multi-dimensional to
-                1-dimensional data.
+            signal_reduction (darsia.SignalReduction): reduction from multi-dimensional
+                to 1-dimensional data; default value (None) denotes an identity
+                operation.
             balancing (darsia.Model, optional): operator balancing the signal, e.g., in
-                different facies.
+                different facies; the default value (None) denotes an identity
+                operation.
             restoration (darsia.TVD): regularizer.
-            model (darsia.Model): Conversion of signals to actual physical data.
-            labels (array, optional): labeled image of domain
-            kwargs (keyword arguments): interface to all tuning parameters
+            model (darsia.Model): Conversion of signals to actual physical data; default
+                value (None) denotes an identity operation.
+            labels (array, optional): labeled image of domain; the default value (None)
+                denotes the presence of a homogeneous medium.
+            kwargs (keyword arguments): interface to all tuning parameters.
+
         """
         ########################################################################
 
-        # Fix single baseline image and reference time
-        if not isinstance(base, list):
-            base = [base]
-        self.base: darsia.Image = base[0].copy()
+        self.base: Optional[darsia.Image] = None
         """Baseline image."""
-
-        if self.base.space_dim != 2:
-            raise NotImplementedError
+        if base is not None:
+            if not isinstance(base, list):
+                base = [base]
+            self.base = base[0].copy()
+            # FIXME
+            if self.base.space_dim != 2:
+                raise NotImplementedError
 
         self.signal_reduction = signal_reduction
         """Reduction to scalar signal."""
@@ -86,9 +95,11 @@ class ConcentrationAnalysis:
         """Option for defining differences of images."""
 
         # Define a cleaning filter based on remaining images.
-        self.find_cleaning_filter(base[1:])
+        self.find_cleaning_filter()
 
-        self.mask: np.ndarray = np.ones(self.base.img.shape[:2], dtype=bool)
+        self.mask: Optional[np.ndarray] = (
+            None if self.base is None else np.ones(self.base.img.shape[:2], dtype=bool)
+        )
         """Mask."""
 
         self.verbosity: int = kwargs.get("verbosity", 0)
@@ -107,6 +118,7 @@ class ConcentrationAnalysis:
             base (Image, optional): image array
             mask (np.ndarray, optional): boolean mask, detecting which pixels
                 will be considered, all other will be ignored in the analysis.
+
         """
         if base is not None:
             self.base = base.copy()
@@ -117,38 +129,52 @@ class ConcentrationAnalysis:
 
     def find_cleaning_filter(
         self,
-        baseline_images: list[darsia.Image],
+        baseline_images: Optional[list[darsia.Image]] = None,
         reset: bool = False,
     ) -> None:
         """
-        Determine natural noise by studying a series of baseline images.
+        Determine structural noise by studying a series of baseline images.
         The resulting cleaning filter will be used prior to the conversion
         of signal to concentration. The cleaning filter should be understood
         as thresholding mask.
 
         Args:
-            baseline_images (list of images): series of baseline_images.
+            baseline_images (list of images): series of baseline_images; default: use
+                internally available baseline images.
             reset (bool): flag whether the cleaning filter shall be reset.
+
         """
 
-        self.threshold_cleaning_filter = np.zeros(self.base.img.shape[:2], dtype=float)
+        if baseline_images is None and self.base is not None:
+
+            # Use internal baseline images, if available.
+            baseline_images = self.base[1:]
+
+        self.threshold_cleaning_filter = None
         """Cleaning filter."""
 
-        # Combine the results of a series of images
-        for img in baseline_images:
+        # Learn structural noise from collection of images
+        if baseline_images is not None:
 
-            probe_img = img.copy()
-
-            # Take (unsigned) difference
-            diff = self._subtract_background(probe_img)
-
-            # Extract scalar version
-            monochromatic_diff = self._extract_scalar_information(diff)
-
-            # Consider elementwise max
-            self.threshold_cleaning_filter = np.maximum(
-                self.threshold_cleaning_filter, monochromatic_diff
+            self.threshold_cleaning_filter = np.zeros(
+                self.base.img.shape[:2], dtype=float
             )
+
+            # Combine the results of a series of images
+            for img in baseline_images:
+
+                probe_img = img.copy()
+
+                # Take (unsigned) difference
+                diff = self._subtract_background(probe_img)
+
+                # Extract scalar version
+                monochromatic_diff = self._extract_scalar_information(diff)
+
+                # Consider elementwise max
+                self.threshold_cleaning_filter = np.maximum(
+                    self.threshold_cleaning_filter, monochromatic_diff
+                )
 
     def read_cleaning_filter_from_file(self, path: Union[str, Path]) -> None:
         """
@@ -156,16 +182,18 @@ class ConcentrationAnalysis:
 
         Args:
             path (str or Path): path to cleaning filter array.
+
         """
         # Fetch the threshold mask from file
         self.threshold_cleaning_filter = np.load(path)
 
         # Resize threshold mask if unmatching the size of the base image
-        base_shape = self.base.img.shape[:2]
-        if self.threshold_cleaning_filter.shape[:2] != base_shape:
-            self.threshold_cleaning_filter = cv2.resize(
-                self.threshold_cleaning_filter, tuple(reversed(base_shape))
-            )
+        if self.base is not None:
+            base_shape = self.base.img.shape[:2]
+            if self.threshold_cleaning_filter.shape[:2] != base_shape:
+                self.threshold_cleaning_filter = cv2.resize(
+                    self.threshold_cleaning_filter, tuple(reversed(base_shape))
+                )
 
     def write_cleaning_filter_to_file(self, path_to_filter: Union[str, Path]) -> None:
         """
@@ -173,6 +201,7 @@ class ConcentrationAnalysis:
 
         Args:
             path_to_filter (str or Path): path for storage of the cleaning filter.
+
         """
         path_to_filter = Path(path_to_filter)
         path_to_filter.parents[0].mkdir(parents=True, exist_ok=True)
@@ -188,6 +217,7 @@ class ConcentrationAnalysis:
 
         Returns:
             darsia.Image: concentration
+
         """
         probe_img = copy.deepcopy(img)
 
@@ -233,6 +263,7 @@ class ConcentrationAnalysis:
 
         Args:
             img (np.ndarray): image
+
         """
         if self.verbosity >= 2:
             plt.figure("Difference")
@@ -245,6 +276,7 @@ class ConcentrationAnalysis:
 
         Args:
             img (np.ndarray): image
+
         """
         if self.verbosity >= 2:
             plt.figure("Scalar signal")
@@ -257,6 +289,7 @@ class ConcentrationAnalysis:
 
         Args:
             img (np.ndarray): image
+
         """
         if self.verbosity >= 2:
             plt.figure("Clean signal")
@@ -273,16 +306,30 @@ class ConcentrationAnalysis:
 
         Returns:
             darsia.Image: difference with background image
+
         """
 
-        if self._diff_option == "positive":
-            diff = np.clip(img.img - self.base.img, 0, None)
-        elif self._diff_option == "negative":
-            diff = np.clip(self.base.img - img.img, 0, None)
-        elif self._diff_option == "absolute":
-            diff = skimage.util.compare_images(img.img, self.base.img, method="diff")
+        if self.base is None:
+            if self._diff_option == "positive":
+                diff = np.clip(img.img, 0, None)
+            elif self._diff_option == "negative":
+                diff = np.clip(-img.img, 0, None)
+            elif self._diff_option == "absolute":
+                diff = np.absolute(img.img)
+            else:
+                raise ValueError(f"Diff option {self._diff_option} not supported")
         else:
-            raise ValueError(f"Diff option {self._diff_option} not supported")
+
+            if self._diff_option == "positive":
+                diff = np.clip(img.img - reference, 0, None)
+            elif self._diff_option == "negative":
+                diff = np.clip(reference - img.img, 0, None)
+            elif self._diff_option == "absolute":
+                diff = skimage.util.compare_images(
+                    img.img, self.base.img, method="diff"
+                )
+            else:
+                raise ValueError(f"Diff option {self._diff_option} not supported")
 
         return diff
 
@@ -295,8 +342,12 @@ class ConcentrationAnalysis:
 
         Returns:
             np.ndarray: monochromatic reduction of the array
+
         """
-        return self.signal_reduction(img)
+        if self.signal_reduction is None:
+            return img
+        else:
+            return self.signal_reduction(img)
 
     def _clean_signal(self, img: np.ndarray) -> np.ndarray:
         """
@@ -307,6 +358,7 @@ class ConcentrationAnalysis:
 
         Returns:
             np.ndarray: cleaned image
+
         """
         return (
             img
@@ -326,6 +378,7 @@ class ConcentrationAnalysis:
 
         Returns:
             np.ndarray: balanced image
+
         """
         if self.balancing is not None:
             return self.balancing(img)
@@ -361,6 +414,7 @@ class ConcentrationAnalysis:
 
         Returns:
             np.ndarray: physical data
+
         """
         # Obtain data from model
         data = self.model(signal)

--- a/src/darsia/multi_image_analysis/concentrationanalysis.py
+++ b/src/darsia/multi_image_analysis/concentrationanalysis.py
@@ -33,7 +33,7 @@ class ConcentrationAnalysis:
                 darsia.Image,
                 list[darsia.Image],
             ]
-        ],
+        ] = None,
         signal_reduction: darsia.SignalReduction = None,
         balancing: Optional[darsia.Model] = None,
         restoration: Optional[darsia.TVD] = None,

--- a/src/darsia/multi_image_analysis/model_calibration.py
+++ b/src/darsia/multi_image_analysis/model_calibration.py
@@ -7,6 +7,7 @@ in ConcentrationAnalysis.calibrate_model()
 
 import abc
 
+import matplotlib.pyplot as plt
 import numpy as np
 import scipy.optimize as optimize
 from scipy import interpolate
@@ -60,9 +61,7 @@ class AbstractModelObjective:
             self.model.update_model_parameters(parameters)
 
     def calibrate_model(
-        self,
-        images: list[darsia.Image],
-        options: dict,
+        self, images: list[darsia.Image], options: dict, plot_result: bool = False
     ) -> bool:
         """
         Utility for calibrating the model used in darsia.ConcentrationAnalysis.
@@ -74,6 +73,8 @@ class AbstractModelObjective:
             images (list of darsia.Image): calibration images
             options (dict): container holding tuning information for the numerical
                 calibration routine
+            plot_result (bool): flag controlling whether the calibration is displayed
+                in a plot.
 
         Returns:
             bool: success of the calibration study.
@@ -143,6 +144,12 @@ class AbstractModelObjective:
         # Update model (use functionality from calibration)
         self.update_model_for_calibration(opt_result.x, options)
 
+        # Allow for post-analysis. Plot the result.
+        if plot_result:
+            self._visualize_model_calibration(
+                images_smooth_signal, images_diff, times, options
+            )
+
         return opt_result.success
 
 
@@ -190,13 +197,13 @@ class InjectionRateModelObjectiveMixin(AbstractModelObjective):
             options (dict): dictionary with objective value, here the injection rate
 
         Returns:
-            callable: objetive function
+            callable: objective function
 
         """
 
         # Fetch the injection rate and geometry
-        injection_rate = options.get("injection_rate")  # in ml/hrs
-        geometry = options.get("geometry")
+        injection_rate = options["injection_rate"]  # in ml/hrs
+        geometry = options["geometry"]
 
         # Define the objective function
         def objective_function(params: np.ndarray) -> float:
@@ -227,11 +234,73 @@ class InjectionRateModelObjectiveMixin(AbstractModelObjective):
             # Extract the slope and convert to
             effective_injection_rate = ransac.estimator_.coef_[0]
 
+            # Cache result for possible post-analysis
+            self._slope = ransac.estimator_.coef_[0]
+            self._intercept = ransac.estimator_.intercept_
+
             # Measure deffect
             defect = effective_injection_rate - injection_rate
             return defect**2
 
         return objective_function
+
+    def _visualize_model_calibration(
+        self,
+        input_images: list[np.ndarray],
+        images_diff: list[np.ndarray],
+        times: list[float],
+        options: dict,
+    ) -> None:
+        """
+        Illustrate result of calibration.
+
+        Args:
+            input_images (list of np.ndarray): input for _convert_signal
+            images_diff (list of np.ndarray): plain differences wrt background image
+            times (list of float): times in hrs
+            options (dict): dictionary with objective value, here the injection rate
+
+        """
+        # Fetch the injection rate and geometry
+        geometry = options["geometry"]
+
+        # For each image, compute the total concentration, based on the currently
+        # set tuning parameters, and compute the relative time.
+        M3_TO_ML = 1e6
+        volumes = [
+            geometry.integrate(self._convert_signal(img, diff)) * M3_TO_ML
+            for img, diff in zip(input_images, images_diff)
+        ]
+
+        ## ! ---- Find intercept through RANSAC analysis
+
+        # Plot the evolution of the rescaled signal over time, and in addtion a dashed
+        # line corresponding to the reference injection rate.
+        plt.figure("Model calibration")
+        plt.plot(times, volumes)
+        plt.plot(
+            times,
+            [self._intercept + self._slope * time for time in times],
+            color="black",
+            linestyle=(0, (5, 5)),
+        )
+        plt.xlabel("time [hrs]")
+        plt.ylabel("volume [ml]")
+        plt.legend(["rescaled signal", "reference"])
+        plt.show()
+
+    def model_calibration_postanalysis(self) -> None:
+        """Interpret calibration result."""
+
+        # Interpret the results of the regression
+        print(
+            f"The effective injection rate for the calibration images is {self._slope} ml/hrs."
+        )
+        print(f"The signal at absolute time 0 is {self._intercept} ml.")
+
+        # Determine the time of zero signal
+        time_zero_signal = -self._intercept / self._slope
+        print(f"The time of zero signal is deducted to be {time_zero_signal} hrs.")
 
 
 class AbsoluteVolumeModelObjectiveMixin(AbstractModelObjective):

--- a/src/darsia/signals/models/linearmodel.py
+++ b/src/darsia/signals/models/linearmodel.py
@@ -1,5 +1,6 @@
 """
 Module containing a linear (affine) conversion from signals to data.
+
 """
 
 from typing import Optional
@@ -10,11 +11,63 @@ import numpy as np
 import darsia
 
 
-class LinearModel(darsia.Model):
-    """
-    Linear model, applying an affine conversion for signals to data.
+class ScalingModel(darsia.Model):
+    """Linear model (plain scaling)."""
 
-    """
+    def __init__(
+        self,
+        key: str = "",
+        **kwargs,
+    ) -> None:
+
+        self._scaling = kwargs.get(key + "scaling", 1.0)
+
+        self.volumes = None
+
+    def update(
+        self,
+        scaling: Optional[float] = None,
+    ) -> None:
+        """
+        Update of internal parameters.
+
+        Args:
+            scaling (float, optional): slope
+
+        """
+
+        if scaling is not None:
+            self._scaling = scaling
+
+    def update_model_parameters(self, parameters: np.ndarray) -> None:
+        """
+        Short cut to update scaling and offset parameters using a
+        general function signature.
+
+        The main use is the model calibration. Do not update the offset.
+
+        Args:
+            parameters (np.ndarray): 2-array containing scaling and offset values.
+
+        """
+        self.update(scaling=parameters[0])
+
+    def __call__(self, img: np.ndarray) -> np.ndarray:
+        """
+        Application of linear model.
+
+        Args:
+            img (np.ndarray): image
+
+        Returns:
+            np.ndarray: converted signal
+
+        """
+        return self._scaling * img
+
+
+class LinearModel(darsia.Model):
+    """Linear model, applying an affine conversion for signals to data."""
 
     def __init__(
         self,


### PR DESCRIPTION
Allow all components, including the baseline image to be None, when setting up a concentration analysis. This change will allow to use the concentration analysis workflows for other images than optical images.