### PR TITLE
EMD for time series

### DIFF
--- a/src/darsia/image/arithmetics.py
+++ b/src/darsia/image/arithmetics.py
@@ -55,7 +55,7 @@ def weight(img: darsia.Image, weight: Union[float, int, darsia.Image]) -> darsia
     elif isinstance(weight, np.ndarray) and np.allclose(
         weight.shape, weighted_img.shape[weighted_img.space_dim :]
     ):
-        # Spatially constant weight, but differing for time and data inidices.
+        # Spatially constant weight, but differing for time and data indices.
         shape = weighted_img.img.shape
         weighted_img.img = np.multiply(
             weighted_img.img,

--- a/src/darsia/image/arithmetics.py
+++ b/src/darsia/image/arithmetics.py
@@ -50,6 +50,18 @@ def weight(img: darsia.Image, weight: Union[float, int, darsia.Image]) -> darsia
         # Rescale
         weighted_img.img = np.multiply(weighted_img.img, weight.img)
 
+    elif isinstance(weight, np.ndarray) and np.allclose(
+        weight.shape, weighted_img.shape[weighted_img.space_dim :]
+    ):
+        # Spatially constant weight, but differing for time and data inidices.
+        shape = weighted_img.img.shape
+        weighted_img.img = np.multiply(
+            weighted_img.img,
+            np.outer(
+                np.ones(weighted_img.coordinatesystem.shape, dtype=float), weight
+            ).reshape(shape),
+        )
+
     else:
         raise ValueError
 

--- a/src/darsia/image/arithmetics.py
+++ b/src/darsia/image/arithmetics.py
@@ -33,7 +33,7 @@ def weight(img: darsia.Image, weight: Union[float, int, darsia.Image]) -> darsia
 
     elif isinstance(weight, darsia.Image):
         assert darsia.check_equal_coordinatesystems(
-            img.coordinatesystem, weight.coordinatesystem, exclude_size = True
+            img.coordinatesystem, weight.coordinatesystem, exclude_size=True
         )
         space_dim = img.space_dim
         assert len(weight.img.shape) == space_dim

--- a/src/darsia/image/arithmetics.py
+++ b/src/darsia/image/arithmetics.py
@@ -32,7 +32,9 @@ def weight(img: darsia.Image, weight: Union[float, int, darsia.Image]) -> darsia
         weighted_img.img *= weight
 
     elif isinstance(weight, darsia.Image):
-        assert darsia.check_equal_coordinatesystems(img, weight)
+        assert darsia.check_equal_coordinatesystems(
+            img.coordinatesystem, weight.coordinatesystem, exclude_size = True
+        )
         space_dim = img.space_dim
         assert len(weight.img.shape) == space_dim
 

--- a/src/darsia/image/arithmetics.py
+++ b/src/darsia/image/arithmetics.py
@@ -32,8 +32,7 @@ def weight(img: darsia.Image, weight: Union[float, int, darsia.Image]) -> darsia
         weighted_img.img *= weight
 
     elif isinstance(weight, darsia.Image):
-        assert np.allclose(img.origin, weight.origin)
-        assert np.allclose(img.dimensions, weight.dimensions)
+        assert darsia.check_equal_coordinatesystems(img, weight)
         space_dim = img.space_dim
         assert len(weight.img.shape) == space_dim
 

--- a/src/darsia/image/coordinatesystem.py
+++ b/src/darsia/image/coordinatesystem.py
@@ -217,3 +217,46 @@ class CoordinateSystem:
 
         """
         raise NotImplementedError
+
+
+def check_equal_coordinatesystems(
+    coordinatesystem1: CoordinateSystem, coordinatesystem2: CoordinateSystem
+) -> bool:
+    """Check whether two coordinate systems are equivalent, i.e., they share basic
+    attributes.
+
+    Args:
+        coordinatesystem1 (CoordinateSystem): first coordinate system
+        coordinatesystem2 (CoordinateSystem): second coordinate system
+
+    Returns:
+        bool: True iff the two coordinate systems are equivalent.
+
+    """
+    success = True
+    success = success and coordinatesystem1.indexing == coordinatesystem2.indexing
+    success = success and coordinatesystem1.dim == coordinatesystem2.dim
+    success = success and np.allclose(coordinatesystem1.shape, coordinatesystem2.shape)
+    success = success and np.allclose(
+        coordinatesystem1.dimensions, coordinatesystem2.dimensions
+    )
+    success = success and coordinatesystem1.axes == coordinatesystem2.axes
+    for axis in coordinatesystem1.axes:
+        success = (
+            success
+            and coordinatesystem1.voxel_size[axis] == coordinatesystem2.voxel_size[axis]
+        )
+    success = success and np.allclose(
+        coordinatesystem1._coordinate_of_origin_voxel,
+        coordinatesystem2._coordinate_of_origin_voxel,
+    )
+    success = success and np.allclose(
+        coordinatesystem1._coordinate_of_opposite_voxel,
+        coordinatesystem2._coordinate_of_opposite_voxel,
+    )
+    success = success and np.allclose(
+        coordinatesystem1._voxel_of_origin_coordinate,
+        coordinatesystem2._voxel_of_origin_coordinate,
+    )
+
+    return success

--- a/src/darsia/image/coordinatesystem.py
+++ b/src/darsia/image/coordinatesystem.py
@@ -220,7 +220,9 @@ class CoordinateSystem:
 
 
 def check_equal_coordinatesystems(
-    coordinatesystem1: CoordinateSystem, coordinatesystem2: CoordinateSystem
+    coordinatesystem1: CoordinateSystem,
+    coordinatesystem2: CoordinateSystem,
+    exclude_size: bool = False,
 ) -> bool:
     """Check whether two coordinate systems are equivalent, i.e., they share basic
     attributes.
@@ -228,6 +230,7 @@ def check_equal_coordinatesystems(
     Args:
         coordinatesystem1 (CoordinateSystem): first coordinate system
         coordinatesystem2 (CoordinateSystem): second coordinate system
+        exclude_size (bool): flag controlling whether the size quantities are exluded.
 
     Returns:
         bool: True iff the two coordinate systems are equivalent.
@@ -236,16 +239,21 @@ def check_equal_coordinatesystems(
     success = True
     success = success and coordinatesystem1.indexing == coordinatesystem2.indexing
     success = success and coordinatesystem1.dim == coordinatesystem2.dim
-    success = success and np.allclose(coordinatesystem1.shape, coordinatesystem2.shape)
+    if not exclude_size:
+        success = success and np.allclose(
+            coordinatesystem1.shape, coordinatesystem2.shape
+        )
     success = success and np.allclose(
         coordinatesystem1.dimensions, coordinatesystem2.dimensions
     )
     success = success and coordinatesystem1.axes == coordinatesystem2.axes
-    for axis in coordinatesystem1.axes:
-        success = (
-            success
-            and coordinatesystem1.voxel_size[axis] == coordinatesystem2.voxel_size[axis]
-        )
+    if not exclude_size:
+        for axis in coordinatesystem1.axes:
+            success = (
+                success
+                and coordinatesystem1.voxel_size[axis]
+                == coordinatesystem2.voxel_size[axis]
+            )
     success = success and np.allclose(
         coordinatesystem1._coordinate_of_origin_voxel,
         coordinatesystem2._coordinate_of_origin_voxel,
@@ -254,9 +262,10 @@ def check_equal_coordinatesystems(
         coordinatesystem1._coordinate_of_opposite_voxel,
         coordinatesystem2._coordinate_of_opposite_voxel,
     )
-    success = success and np.allclose(
-        coordinatesystem1._voxel_of_origin_coordinate,
-        coordinatesystem2._voxel_of_origin_coordinate,
-    )
+    if not exclude_size:
+        success = success and np.allclose(
+            coordinatesystem1._voxel_of_origin_coordinate,
+            coordinatesystem2._voxel_of_origin_coordinate,
+        )
 
     return success

--- a/src/darsia/measure/emd.py
+++ b/src/darsia/measure/emd.py
@@ -42,7 +42,7 @@ class EMD:
             img_2 (darsia.Image): image 2
 
         Returns:
-            float: distance between img_1 and img_2.
+            float or array: distance between img_1 and img_2.
 
         """
         # Preprocess images
@@ -52,22 +52,25 @@ class EMD:
         # Compatibilty check
         self._compatibility_check(preprocessed_img_1, preprocessed_img_2)
 
-        # Pixel dimensions
-        dx_1 = tuple(preprocessed_img_1.voxel_size)
-        dx_2 = tuple(preprocessed_img_2.voxel_size)
-
         # Normalization
-        integral_1, normalized_img_1 = self._normalize(preprocessed_img_1)
-        integral_2, normalized_img_2 = self._normalize(preprocessed_img_2)
+        integral = self._sum(preprocessed_img_1)
+        normalized_img_1 = self._normalize(preprocessed_img_1)
+        normalized_img_2 = self._normalize(preprocessed_img_2)
 
         # Convert format to a signature
-        sig_1 = self._img_to_sig(normalized_img_1, dx=dx_1)
-        sig_2 = self._img_to_sig(normalized_img_2, dx=dx_2)
+        dx = tuple(preprocessed_img_1.voxel_size)
+        time_num = preprocessed_img_1.time_num
+        sig_1 = self._img_to_sig(normalized_img_1, dx=dx, time_num=time_num)
+        sig_2 = self._img_to_sig(normalized_img_2, dx=dx, time_num=time_num)
 
         # Compute EMD distance
-        dist, _, flow = cv2.EMD(sig_1, sig_2, cv2.DIST_L2)
+        dist = np.zeros(time_num, dtype=float)
+        for i in range(time_num):
+            dist[i], _, flow = cv2.EMD(sig_1[i], sig_2[i], cv2.DIST_L2)
 
-        return dist * integral_1
+        rescaled_distance = np.multiply(dist, integral)
+
+        return float(rescaled_distance) if time_num == 1 else rescaled_distance
 
     def _preprocess(self, img: darsia.Image) -> darsia.Image:
         """
@@ -103,6 +106,9 @@ class EMD:
         # Scalar valued
         assert img_1.scalar and img_2.scalar
 
+        # Series
+        assert img_1.time_num == img_2.time_num
+
         # Two-dimensional
         assert img_1.space_dim == 2 and img_2.space_dim == 2
 
@@ -132,7 +138,7 @@ class EMD:
             sum_over_time = np.sum(sum_over_time, axis=0)
         return sum_over_time
 
-    def _normalize(self, img: darsia.Image) -> tuple[float, np.ndarray]:
+    def _normalize(self, img: darsia.Image) -> np.ndarray:
         """
         Normalization of images to images with sum 1.
 
@@ -146,16 +152,20 @@ class EMD:
         """
         integral = self._sum(img)
         normalized_img = np.divide(img.img, integral)
-        return integral, normalized_img
+        return normalized_img
 
     def _img_to_sig(
-        self, img: np.ndarray, dx: Union[float, tuple[float, float]] = 1
+        self,
+        img: np.ndarray,
+        dx: Union[float, tuple[float, float]] = 1.0,
+        time_num: int = 1,
     ) -> np.ndarray:
         """Convert a 2D array to a signature for cv2.EMD.
 
         Args:
             img (array): image
-            dx: (float or tuple): distance from one pixel to another
+            dx (float or tuple): distance from one pixel to another
+            time_num (int): number of time steps
 
         Returns:
             np.ndarray: signature
@@ -165,14 +175,25 @@ class EMD:
             dx = (dx, dx)
         del_y, del_x = dx
 
-        sig = np.empty((img.size, 3), dtype=np.float32)
-        count = 0
-        for row in range(img.shape[0]):
-            for col in range(img.shape[1]):
-                sig[count] = np.array([img[row, col], col * del_x, row * del_y]).astype(
-                    np.float32
-                )
-                count += 1
+        def _signature_for_slice(time_index: int = 0):
+            """Auxiliary function. Create signature for single time slice."""
+            sig = np.empty((int(img.size / time_num), 3), dtype=np.float32)
+            count = 0
+            for row in range(img.shape[0]):
+                for col in range(img.shape[1]):
+                    sig[count] = np.array(
+                        [
+                            np.atleast_3d(img)[row, col, time_index],
+                            col * del_x,
+                            row * del_y,
+                        ]
+                    ).astype(np.float32)
+                    count += 1
+            return sig
+
+        sig = np.empty((time_num, int(img.size / time_num), 3), dtype=np.float32)
+        for i in range(time_num):
+            sig[i] = _signature_for_slice(i)
 
         return sig
 

--- a/src/darsia/measure/emd.py
+++ b/src/darsia/measure/emd.py
@@ -55,7 +55,6 @@ class EMD:
         # Pixel dimensions
         dx_1 = tuple(preprocessed_img_1.voxel_size)
         dx_2 = tuple(preprocessed_img_2.voxel_size)
-        assert np.allclose(dx_1, dx_2)
 
         # Normalization
         integral_1, normalized_img_1 = self._normalize(preprocessed_img_1)
@@ -106,6 +105,12 @@ class EMD:
 
         # Two-dimensional
         assert img_1.space_dim == 2 and img_2.space_dim == 2
+
+        # Check whether the coordinate system is compatible
+        assert darsia.check_equal_coordinatesystems(
+            img_1.coordinatesystem, img_2.coordinatesystem
+        )
+        assert np.allclose(img_1.voxel_size, img_2.voxel_size)
 
         # Compatible distributions - comparing sums is sufficient since it is implicitly
         # assumed that the coordinate systems are equivalent. Check each time step

--- a/src/darsia/measure/integration.py
+++ b/src/darsia/measure/integration.py
@@ -134,6 +134,33 @@ class Geometry:
             weighted_sum = np.sum(weighted_sum, axis=0)
         return weighted_sum
 
+    def normalize(
+        self, img: darsia.Image, img_ref: darsia.Image, return_ratio: bool = False
+    ) -> Union[darsia.Image, tuple[darsia.Image, np.ndarray]]:
+        """Normalize image with respect to another one, such that both have the same
+        integral.
+
+        Args:
+            img (darsia.Image): image to be rescaled
+            img_ref (darsia.Image): reference image
+            return_ratio (bool): flag controlling whether the ratio between reference
+                and original integrals is returned
+
+        Returns:
+            darsia.Image: rescaled image
+            np.ndarray, optional: ratio between reference and original integrals
+
+        """
+        integral_ref = self.integrate(img_ref)
+        integral = self.integrate(img)
+        ratio = np.divide(integral_ref, integral)
+        rescaled_img = darsia.weight(img, ratio)
+
+        if return_ratio:
+            return rescaled_img, ratio
+        else:
+            return rescaled_img
+
 
 class WeightedGeometry(Geometry):
     """Geometry with weighted volume."""

--- a/tests/unit/test_arithmetics.py
+++ b/tests/unit/test_arithmetics.py
@@ -25,8 +25,8 @@ def test_array_weight_2d():
 
 def test_incompatible_weight_2d():
 
-    image = darsia.Image(np.ones((6, 8), dtype=float), dim=2)
-    weight = darsia.Image(2 * np.ones((3, 4)), dim=2)
+    image = darsia.Image(np.ones((6, 8), dtype=float), dim=2, dimensions=[6, 8])
+    weight = darsia.Image(2 * np.ones((3, 4)), dim=2, dimensions=[6, 8])
 
     weighted_image = darsia.weight(image, weight)
     assert np.allclose(weighted_image.img, 2 * np.ones((6, 8)))

--- a/tests/unit/test_emd.py
+++ b/tests/unit/test_emd.py
@@ -15,8 +15,8 @@ def test_emd_2d_single_pixel():
     mass2_array[6, 12] = 1
 
     # Convert the arrays to actual DarSIA Images
-    mass1 = darsia.Image(mass1_array, width=2, height=1)
-    mass2 = darsia.Image(mass2_array, width=2, height=1)
+    mass1 = darsia.Image(mass1_array, width=2, height=1, scalar=True)
+    mass2 = darsia.Image(mass2_array, width=2, height=1, scalar=True)
 
     # Setup EMD object
     emd = darsia.EMD()
@@ -30,7 +30,7 @@ def test_emd_2d_single_pixel():
 
 
 def test_emd_2d_resize():
-    """Test simple EMD for 2d distributions with physical dimenions."""
+    """Test simple EMD for 2d distributions with physical dimensions."""
 
     # Create two mass distributions with identical mass, equal to 1
     mass1_array = np.zeros((10, 20), dtype=float)
@@ -39,8 +39,8 @@ def test_emd_2d_resize():
     mass2_array[6, 12] = 1
 
     # Convert the arrays to actual DarSIA Images
-    mass1 = darsia.Image(mass1_array, width=2, height=1)
-    mass2 = darsia.Image(mass2_array, width=2, height=1)
+    mass1 = darsia.Image(mass1_array, width=2, height=1, scalar=True)
+    mass2 = darsia.Image(mass2_array, width=2, height=1, scalar=True)
 
     # Setup EMD object, including a resize routine (needed for cv2.EMD)
     resize = darsia.Resize(

--- a/tests/unit/test_geometry.py
+++ b/tests/unit/test_geometry.py
@@ -439,3 +439,39 @@ def test_integration_image_series():
     assert np.allclose(
         integral, 0.25**2 * (0.5 + 0.75 - 0.2 + 0.6 + 0.1) * np.ones(2)
     )
+
+
+def test_geometry_normalization():
+    """Test normalization performed by geomtries."""
+
+    space_dim = 2
+    num_voxels = (2, 4)  # rows x cols
+    dimensions = [0.5, 1.0]  # height x width
+    geometry = darsia.Geometry(
+        space_dim=space_dim, num_voxels=num_voxels, dimensions=dimensions
+    )
+
+    # Check voxel volume which should have height and width equal to 0.25
+    assert geometry.voxel_volume == 0.25**2
+
+    # Hardcoded data of compatible size
+    data = np.zeros(num_voxels, dtype=float)
+    data[0, 2] = 0.5
+    data[0, 3] = 0.75
+    data[1, 0] = -0.2
+    data[1, 1] = 0.6
+    data[1, 2] = 0.1
+    image = darsia.Image(data, dimensions=dimensions, series=False, scalar=True)
+
+    # Create random image
+    random_data = np.random.rand(2, 4)
+    random_image = darsia.Image(
+        random_data, dimensions=dimensions, series=False, scalar=True
+    )
+
+    # Normalize random image
+    normalized_random_image = geometry.normalize(random_image, image)
+
+    # Test integration
+    integral = geometry.integrate(normalized_random_image)
+    assert np.isclose(integral, 0.25**2 * (0.5 + 0.75 - 0.2 + 0.6 + 0.1))


### PR DESCRIPTION
Given two time series (supposedly same configurations), the emd distance between the two series is computed by computing the distance for each time step independently. The result is then a vector of the respective distances.

At the same time add functionality to normalize Images. For comaptbility, several routines had to be extended to time series and vectorial data to cover the general case.