### PR TITLE
Extend resize capabilities

### DIFF
--- a/examples/distances.py
+++ b/examples/distances.py
@@ -36,7 +36,7 @@ if False:
 # Determine distance between different masses
 resize = darsia.Resize(
     **{
-        "resize dsize": (140, 75),  # rows, cols
+        "resize shape": (75, 140),
         "resize interpolation": "inter_area",
         "resize conservative": True,
     }

--- a/src/darsia/presets/fluidflower/benchmarkco2model.py
+++ b/src/darsia/presets/fluidflower/benchmarkco2model.py
@@ -20,7 +20,7 @@ def benchmark_binary_cleaning_preset(
         options (dict): options same as in benchmark_concentration_analysis_preset.
 
     """
-    original_size = base.img.shape[:2]
+    original_shape = base.img.shape[:2]
     binary_cleaning = darsia.CombinedModel(
         [
             # Binary inpainting
@@ -29,7 +29,7 @@ def benchmark_binary_cleaning_preset(
             # Resize and Smoothing
             darsia.Resize(dtype=np.float32, key="prior ", **options),
             darsia.TVD(key="prior ", **options),
-            darsia.Resize(dsize=tuple(reversed(original_size))),
+            darsia.Resize(shape=original_shape),
             # Conversion to boolean
             darsia.StaticThresholdModel(0.5),
         ]
@@ -74,12 +74,12 @@ def benchmark_concentration_analysis_preset(
 
     ########################################################################
     # Define restoration object - coarsen, tvd, resize
-    original_size = base.img.shape[:2]
+    original_shape = base.img.shape[:2]
     restoration = darsia.CombinedModel(
         [
             darsia.Resize(key="restoration ", **options),
             darsia.TVD(key="restoration ", **options),
-            darsia.Resize(dsize=tuple(reversed(original_size))),
+            darsia.Resize(shape=original_shape),
         ]
     )
 

--- a/src/darsia/presets/fluidflower/fluidflowertraceranalysis.py
+++ b/src/darsia/presets/fluidflower/fluidflowertraceranalysis.py
@@ -73,12 +73,12 @@ class FluidFlowerTracerAnalysis(darsia.TracerAnalysis):
 
         ########################################################################
         # Define restoration object - coarsen, tvd, resize
-        original_size = self.base.img.shape[:2]
+        original_shape = self.base.img.shape[:2]
         restoration = darsia.CombinedModel(
             [
                 darsia.Resize(key="restoration ", **self.config["tracer"]),
                 darsia.TVD(key="restoration ", **self.config["tracer"]),
-                darsia.Resize(dsize=tuple(reversed(original_size))),
+                darsia.Resize(shape=original_shape),
             ]
         )
 

--- a/src/darsia/restoration/resize.py
+++ b/src/darsia/restoration/resize.py
@@ -1,7 +1,6 @@
 """
-Module containing wrappers to resize routines
-from skimage and cv2. Access is given through
-objects.
+Module containing wrappers to resize routines from skimage and cv2. Access is given
+through objects. Also contains utility routine which equalizes voxel size lengths.
 
 """
 
@@ -160,3 +159,33 @@ class Resize:
             return type(img)(resized_img_array, **meta)
         else:
             return resized_img_array
+
+
+def equalize_voxel_size(
+    image: darsia.Image, voxel_size: Optional[float] = None, **kwargs
+) -> darsia.Image:
+    """Resize routine which keeps physical dimensions, but unifies the voxel length.
+
+    Args:
+        image (darsia.Image): image to be resized
+        voxel_size (float, optional): side length, min of the voxel side of the image
+            if None.
+        keyword arguments:
+            interpolation (str): interpolation type used for resize
+
+    Returns:
+        darsia.Image: resized image
+
+    """
+    # Fetch dimensions to be kept
+    dimensions = image.dimensions
+
+    # Determine resulting shape of the resized image
+    if voxel_size is None:
+        voxel_size = min(image.voxel_size)
+    shape = tuple(int(d / voxel_size) for d in dimensions)
+
+    # Perform resize
+    interpolation = kwargs.get("interpolation")
+    resize = Resize(shape=shape, interpolation=interpolation)
+    return resize(image)

--- a/src/darsia/restoration/resize.py
+++ b/src/darsia/restoration/resize.py
@@ -32,7 +32,7 @@ class Resize:
 
     def __init__(
         self,
-        dsize: Optional[tuple[int]] = None,
+        shape: Optional[tuple[int]] = None,
         fx: Optional[float] = None,
         fy: Optional[float] = None,
         interpolation: Optional[str] = None,
@@ -42,8 +42,7 @@ class Resize:
     ) -> None:
         """
         Args:
-            dsize (tuple of int, optional): desired number of col and row
-                after transformation.
+            shape (tuple of int, optional): desired shape (in matrix indexing)
             fx (float, optional): resize factor in x-dimension.
             fy (float, optional): resize factor in y-dimension.
             interpolation (str, optional): interpolation method, default: None, invoking
@@ -53,16 +52,19 @@ class Resize:
         """
 
         # Cache parameters
-        self.dsize = kwargs.get(key + "resize dsize", None) if dsize is None else dsize
+        self.shape = kwargs.get(key + "resize shape", None) if shape is None else shape
         general_f = kwargs.get(key + "resize", None)
         self.fx = kwargs.get(key + "resize x", general_f) if fx is None else fx
         self.fy = kwargs.get(key + "resize y", general_f) if fy is None else fy
         self.dtype = kwargs.get(key + "resize dtype", None) if dtype is None else dtype
 
         # Safety checks - double check resize options
-        if self.dsize is None:
+        if self.shape is None:
             self.fx = 1 if self.fx is None else self.fx
             self.fy = 1 if self.fy is None else self.fy
+        else:
+            # cv2 expects a flipped order
+            self.dsize = tuple(reversed(self.shape))
 
         # Convert to CV2 format
         # NOTE: The default value for interpolation in cv2 is depending on whether

--- a/tests/unit/test_emd.py
+++ b/tests/unit/test_emd.py
@@ -45,7 +45,7 @@ def test_emd_2d_resize():
     # Setup EMD object, including a resize routine (needed for cv2.EMD)
     resize = darsia.Resize(
         **{
-            "resize dsize": (20, 40),  # rows, cols
+            "resize shape": (20, 40),  # rows, cols
             "resize interpolation": "inter_area",
             "resize conservative": True,
         }

--- a/tests/unit/test_resize.py
+++ b/tests/unit/test_resize.py
@@ -1,0 +1,49 @@
+"""Unit tests for darsia.Resize."""
+
+import numpy as np
+
+import darsia
+
+
+def test_equalize_voxel_size_default():
+    """Test equalization of voxel size for image with unequal voxel size."""
+
+    # Create image with shape and dimensions not complying with each other.
+    array = np.ones((10, 10))
+    image = darsia.Image(array, width=2, height=1, scalar=True)
+
+    # Check that voxel size unequal
+    original_voxel_size = image.voxel_size
+    assert not np.isclose(original_voxel_size[0], original_voxel_size[1])
+
+    # Transform to same voxel size (using the default option)
+    resized_image = darsia.equalize_voxel_size(image)
+    resized_voxel_size = resized_image.voxel_size
+    assert np.isclose(resized_voxel_size[0], resized_voxel_size[1])
+
+    # Check whether the dimensions are still the same
+    original_dimensions = image.dimensions
+    resized_dimensions = resized_image.dimensions
+    assert np.allclose(original_dimensions, resized_dimensions)
+
+
+def test_equalize_voxel_size():
+    """Test equalization of voxel size for image with unequal voxel size."""
+
+    # Create image with shape and dimensions not complying with each other.
+    array = np.ones((10, 10))
+    image = darsia.Image(array, width=2, height=1, scalar=True)
+
+    # Check that voxel size unequal
+    original_voxel_size = image.voxel_size
+    assert not np.isclose(original_voxel_size[0], original_voxel_size[1])
+
+    # Transform to same voxel size (using the default option)
+    resized_image = darsia.equalize_voxel_size(image, voxel_size=0.05)
+    resized_voxel_size = resized_image.voxel_size
+    assert np.isclose(resized_voxel_size[0], resized_voxel_size[1])
+
+    # Check whether the dimensions are still the same
+    original_dimensions = image.dimensions
+    resized_dimensions = resized_image.dimensions
+    assert np.allclose(original_dimensions, resized_dimensions)


### PR DESCRIPTION
1. Use shape and not cv2 related dsize for providing desired shape of transformed images.
2. Add resize routine which equalizes voxel size items.