### PR TITLE
Overhaul time

### DIFF
--- a/src/darsia/image/image.py
+++ b/src/darsia/image/image.py
@@ -281,7 +281,15 @@ class Image:
     def reset_reference_time(self) -> None:
         """Pick date of first image in a series as reference date."""
 
-        self.reference_date = self.date[0] if isinstance(self.date, list) else self.date
+        if self._is_none(self.date):
+            # Manually reset time
+            base_time = self.time[0]
+            self.time = [time - base_time for time in self.time]
+        else:
+            self.reference_date = (
+                self.date[0] if isinstance(self.date, list) else self.date
+            )
+            self.set_time()
 
     def copy(self) -> Image:
         """Copy constructor.

--- a/src/darsia/image/image.py
+++ b/src/darsia/image/image.py
@@ -468,45 +468,37 @@ class Image:
         # Create image with same data type but updates image data and metadata
         return type(self)(img=img, **metadata)
 
-    def time_interval(
-        self,
-        time_indices: Optional[slice] = None,
-        reset_time: bool = False,
-    ) -> Image:
-        """Extraction of temporal subregion.
+    def time_interval(self, indices: slice) -> Image:
+        """Extraction of temporal subregion, only for space-time images.
 
         Args:
-            time_indices (slice, optional): time interval; only for space-time images.
-            reset_time (bool): flag controlling whether relative time is reset.
+            indices (slice): time interval in terms of indices.
 
         Returns:
             Image: image with restricted temporal domain.
 
         Raises:
             ValueError: if image is not a time series.
+            ValueError: if indices is not a slice
 
         """
         # ! ---- Safety checks
 
-        if time_indices is not None and not self.series:
+        if not self.series:
             raise ValueError("Image is not a time-series.")
+        if not isinstance(indices, slice):
+            raise ValueError("indices needs to be a slice")
 
-        # ! ---- Fetch data
+        # ! ---- Adapt data
         if self.scalar:
-            img = self.img[..., time_indices]
+            img = self.img[..., indices]
         else:
-            img = self.img[..., time_indices, :]
+            img = self.img[..., indices, :]
 
-        # ! ---- Update metadata
-
-        # ! ---- Fetch and adapt metadata
+        # ! ---- Adapt metadata
         metadata = self.metadata()
-        metadata["date"] = self.date[time_indices]
-        times = self.time[time_indices]
-        if reset_time:
-            metadata["time"] = [time - times[0] for time in times]
-        else:
-            metadata["time"] = times
+        metadata["date"] = self.date[indices]
+        metadata["time"] = self.time[indices]
 
         return type(self)(img=img, **metadata)
 

--- a/tests/unit/test_subregion.py
+++ b/tests/unit/test_subregion.py
@@ -45,7 +45,8 @@ def test_time_interval_scalar_image_2d_reset_time():
     image = darsia.ScalarImage(arr, **meta)
 
     # Construct subimage
-    sub_image = image.time_interval(slice(1, 3), reset_time=True)
+    sub_image = image.time_interval(slice(1, 3))
+    sub_image.reset_reference_time()
 
     # Test whether the dimensions of the image array are correct
     assert np.allclose(sub_image.shape, (3, 4, 2))


### PR DESCRIPTION
Restructure handling of time and dates by introducing a reference_date, which can be updated etc. This reference_date is then used to define relative times based on dates.

Also simplify extracting time intervals, and remove non-trivial time handling.