### PR TITLE
Update I/O for images

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ isort
 flake8
 mypy
 meshio
+deepdiff

--- a/src/darsia/image/image.py
+++ b/src/darsia/image/image.py
@@ -7,7 +7,6 @@ Images contain the image array, and in addition metadata about origin and dimens
 from __future__ import annotations
 
 import copy
-import json
 import math
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -730,7 +729,6 @@ class Image:
         # Use different plotting styles for different spatial dimensions. In 1d, time
         # series can be visualized in a single plot, and thus receive special treatment.
         if self.space_dim == 1:
-
             # Extract physical coordinates and flatten
             matrix_indices = np.transpose(
                 np.indices(self.img.shape[:1]).reshape((1, -1))
@@ -1371,46 +1369,20 @@ class Image:
 
                     fig_2d.show()
 
-    def write_metadata(self, path: Union[str, Path]) -> None:
-        """
-        Writes the metadata dictionary to a json-file.
+    # ! ---- I/O
 
-        Arguments:
-            path (str): path to the json file
+    def save(self, path: Union[str, Path]) -> None:
+        """Save image to file.
 
-        """
-        metadata = self.extract_metadata()
-        with open(Path(path), "w") as outfile:
-            json.dump(metadata, outfile, indent=4)
+        Store array and metadata in single file.
 
-    def write_array(
-        self,
-        path: Union[str, Path],
-        indexing: str = "matrix",
-        allow_pickle: bool = True,
-    ) -> None:
-        """Auxiliary routine for storing the current image array as npy array.
+        NOTE: Keywords are compatible with imread_from_npz.
 
         Args:
-            path (Path): path to file.
-            indexing (str): If "matrix", the array is stored using matrix indexing,
-                if "Cartesian", the array is stored using Cartesian indexing.
-            allow_pickle (bool): Flag controlling whether pickle is allowed.
+            path (Path): full path to image. Use ending "npz".
 
         """
-        assert indexing.lower() in ["matrix", "cartesian"]
-
-        Path(path).parents[0].mkdir(parents=True, exist_ok=True)
-
-        plain_path = Path(path).with_suffix("")
-
-        np.save(
-            str(plain_path) + ".npy",
-            darsia.matrixToCartesianIndexing(self.img)
-            if indexing.lower() == "cartesian"
-            else self.img,
-            allow_pickle=allow_pickle,
-        )
+        np.savez(str(Path(path)), array=self.img, metadata=self.metadata())
 
     # ! ---- Auxiliary routines
 

--- a/src/darsia/image/imread.py
+++ b/src/darsia/image/imread.py
@@ -71,6 +71,8 @@ def imread(path: Union[str, Path, list[str], list[Path]], **kwargs) -> darsia.Im
     # Depending on the ending run the corresponding routine.
     if suffix == ".npy":
         return imread_from_numpy(path, **kwargs)
+    elif suffix == ".npz":
+        return imread_from_npz(path)
     elif suffix in [".jpg", ".jpeg", ".png", ".tif", ".tiff"]:
         return imread_from_optical(path, **kwargs)
     elif suffix in [".dcm"]:
@@ -98,6 +100,20 @@ def imread_from_numpy(
 
     array = np.load(path, allow_pickle=True)
     image = darsia.Image(array, **kwargs)
+    return image
+
+
+def imread_from_npz(path: Union[Path, list[Path]]) -> darsia.Image:
+    """Converter from npz format to darsia.Image.
+
+    Args:
+        path (Path or list of Path): path(s) to npz files.
+
+    """
+    npzdata = np.load(path, allow_pickle=True)
+    array = npzdata["array"]
+    metadata = npzdata["metadata"].item()
+    image = darsia.Image(array, **metadata)
     return image
 
 

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -8,12 +8,12 @@ import os
 
 import cv2
 import numpy as np
+from deepdiff import DeepDiff
 
 import darsia
 
 
 def test_initialize_image_without_meta():
-
     #############################################################################
     # ! ---- Define image array
     path = f"{os.path.dirname(__file__)}/../../examples/images/baseline.jpg"
@@ -30,7 +30,6 @@ def test_initialize_image_without_meta():
 
 
 def test_initialize_general_image():
-
     #############################################################################
     # ! ---- Define image array
     path = f"{os.path.dirname(__file__)}/../../examples/images/baseline.jpg"
@@ -63,7 +62,6 @@ def test_initialize_general_image():
 
 
 def test_initialize_optical_image():
-
     # ! ---- Define image array
     path = f"{os.path.dirname(__file__)}/../../examples/images/baseline.jpg"
     array = cv2.imread(path)
@@ -102,7 +100,6 @@ def test_initialize_optical_image():
 
 
 def test_monochromatic_optical_images():
-
     # ! ---- Define image array
     path = f"{os.path.dirname(__file__)}/../../examples/images/baseline.jpg"
     array = cv2.imread(path)
@@ -136,3 +133,28 @@ def test_monochromatic_optical_images():
     assert red_image.indexing == "ij"
     assert np.allclose(red_image.dimensions, np.array([1.5, 2.8]))
     assert np.allclose(red_image.origin, np.array([0.0, 1.5]))
+
+
+def test_io():
+    # Test whether the image can be saved and loaded.
+
+    # ! ---- Define image array
+    path = f"{os.path.dirname(__file__)}/../../examples/images/baseline.jpg"
+    array = cv2.imread(path)
+    dimensions = [1.5, 2.8]
+    image = darsia.Image(img=array, dimensions=dimensions)
+    metadata = image.metadata()
+
+    # ! ---- Save image
+    image.save("test_image.npz")
+
+    # ! ---- Load image
+    loaded_image = darsia.imread("test_image.npz")
+    loaded_metadata = loaded_image.metadata()
+
+    # ! ---- Check equality
+    assert np.allclose(image.img, loaded_image.img)
+    assert DeepDiff(metadata, loaded_metadata) == {}
+
+    # ! ---- Remove test file
+    os.remove("test_image.npz")


### PR DESCRIPTION
The routines for storing Image objects was outdated and in particular there was no corresponding reading mechanism.

This PR fixes this issue. Now npz files are used to store arrays and metadata simulatenously. Corresponding reading capability through darsia.imread is provided.