### PR TITLE
Rename l2 regularization -> h1 regularization.

### DIFF
--- a/examples/regularization.py
+++ b/examples/regularization.py
@@ -29,8 +29,8 @@ img_regularized_tvd = darsia.tvd(
     # solver = darsia.CG(maxiter = 20, tol = 1e-3)
 )
 
-# Regularize image using l2 regularization
-img_regularized_l2 = darsia.L2_regularization(
+# Regularize image using H1 regularization
+img_regularized_h1 = darsia.H1_regularization(
     img=img,
     mu=1,
     omega=1,
@@ -43,6 +43,6 @@ plt.figure("img slice")
 plt.imshow(img.img[100, :, :])
 plt.figure("regularized tvd slice")
 plt.imshow(img_regularized_tvd.img[100, :, :])
-plt.figure("regularized l2 slice")
-plt.imshow(img_regularized_l2.img[100, :, :])
+plt.figure("regularized H1 slice")
+plt.imshow(img_regularized_H1.img[100, :, :])
 plt.show()

--- a/src/darsia/__init__.py
+++ b/src/darsia/__init__.py
@@ -51,7 +51,7 @@ from darsia.restoration.tvd import *
 from darsia.restoration.median import *
 from darsia.restoration.resize import *
 from darsia.restoration.binaryinpaint import *
-from darsia.restoration.l2_regularization import *
+from darsia.restoration.h1_regularization import *
 from darsia.restoration.split_bregman_tvd import *
 from darsia.multi_image_analysis.translationanalysis import *
 from darsia.multi_image_analysis.concentrationanalysis import *

--- a/src/darsia/restoration/h1_regularization.py
+++ b/src/darsia/restoration/h1_regularization.py
@@ -1,4 +1,4 @@
-"""L2 regularization of images.
+"""H1 regularization of images.
 
 """
 
@@ -12,7 +12,7 @@ import skimage
 import darsia as da
 
 
-def _L2_regularization_array(
+def _H1_regularization_array(
     img: np.ndarray,
     mu: float,
     omega: float = 1.0,
@@ -20,7 +20,7 @@ def _L2_regularization_array(
     solver: da.Solver = da.Jacobi(),
 ) -> np.ndarray:
     """
-    L2 regularization of numpy arrays.
+    H1 regularization of numpy arrays.
 
     min_u 1/2 ||u - img||_{2,omega}^2 + 1/2 ||nabla u||_{2,mu}^2
 
@@ -73,14 +73,14 @@ def _L2_regularization_array(
     return da.convert_dtype(out_img, img_dtype)
 
 
-def _L2_regularization_image(
+def _H1_regularization_image(
     img: da.Image,
     mu: float,
     omega: float = 1.0,
     dim: int = 2,
     solver: da.Solver = da.Jacobi(),
 ) -> da.Image:
-    """L2 regularization of darsia.Image.
+    """H1 regularization of darsia.Image.
 
     Args:
         img (darsia.Image): image
@@ -95,7 +95,7 @@ def _L2_regularization_image(
 
     """
     regularized_img = img.copy()
-    regularized_img.img = _L2_regularization_array(
+    regularized_img.img = _H1_regularization_array(
         img=img.img,
         mu=mu,
         omega=omega,
@@ -105,14 +105,14 @@ def _L2_regularization_image(
     return regularized_img
 
 
-def L2_regularization(
+def H1_regularization(
     img: Union[np.ndarray, da.Image],
     mu: float,
     omega: float = 1.0,
     dim: int = 2,
     solver: da.Solver = da.Jacobi(),
 ) -> Union[np.ndarray, da.Image]:
-    """Inline application of L2 regularization.
+    """Inline application of H1 regularization.
 
     Args:
         img (np.ndarray or Image): image
@@ -127,7 +127,7 @@ def L2_regularization(
 
     """
     if isinstance(img, np.ndarray):
-        return _L2_regularization_array(
+        return _H1_regularization_array(
             img=img,
             mu=mu,
             omega=omega,
@@ -135,7 +135,7 @@ def L2_regularization(
             solver=solver,
         )
     elif isinstance(img, da.Image):
-        return _L2_regularization_image(
+        return _H1_regularization_image(
             img=img,
             mu=mu,
             omega=omega,


### PR DESCRIPTION
The previsouly called L2 regularization is more often related to as H1 regularization, as it is the H1 seminorm which is added to the data term. Thus, the regularization is characterized by the diffusion equation (compared e.g. to TV regularization where the TV term is added).