### PR TITLE
Anisotropic regularization parameter

### DIFF
--- a/examples/regularization.py
+++ b/examples/regularization.py
@@ -6,31 +6,27 @@ import numpy as np
 import darsia
 
 # Load 3D image
-# image_folder = f"{os.path.dirname(__file__)}/images/"
-image_folder = "C:/Users/erst/src/image_analysis/images/"
+image_folder = f"{os.path.dirname(__file__)}/images/"
 img_path = image_folder + "dicom_3d.npy"
 img = darsia.imread(img_path, dimensions=[0.1, 0.1, 0.1], dim=3)
 
 print("Image shape: ", img.img.shape)
 
-# Make regularization parameter heterogenous (for illustration purposes)
-mu_physical = 4.7e-4 * np.ones_like(img.img)
-mu_physical[:, 0:100, :] = 0.5 * 4.7e-4
-
-mu_physical = 4.7e-4
-
+# Make regularization parameter heterogenous and anisotropic (for illustration purposes)
 mu = np.ones_like(img.img)
 mu[:, 0:100, :] = 0.5
 
+mu_anisotropic = [10 * mu, mu, mu]
+
 # Regularize image using anisotropic tvd
-img_regularized_physical_tvd = darsia.tvd(
+img_regularized_anisotropic_tvd = darsia.tvd(
     img=img,
     method="heterogeneous bregman",
     isotropic=False,
-    weight=mu_physical,
+    weight=mu_anisotropic,
     omega=0.1,
     max_num_iter=30,
-    eps=1e-4,
+    eps=1e-6,
     dim=3,
     verbose=True,
     solver=darsia.Jacobi(maxiter=20),
@@ -44,11 +40,11 @@ img_regularized_tvd = darsia.tvd(
     weight=mu,
     omega=0.1,
     max_num_iter=30,
-    eps=1e-4,
+    eps=1e-6,
     dim=3,
     verbose=True,
-    # solver=darsia.Jacobi(maxiter=20),
-    solver=darsia.CG(maxiter=20, tol=1e-3),
+    solver=darsia.Jacobi(maxiter=20),
+    # solver=darsia.CG(maxiter=20, tol=1e-3),
 )
 
 # Regularize image using H1 regularization
@@ -63,8 +59,8 @@ img_regularized_h1 = darsia.H1_regularization(
 
 plt.figure("img slice")
 plt.imshow(img.img[100, :, :])
-plt.figure("regularized physical tvd slice")
-plt.imshow(img_regularized_physical_tvd.img[100, :, :])
+plt.figure("regularized anisotropic weight tvd slice")
+plt.imshow(img_regularized_anisotropic_tvd.img[100, :, :])
 plt.figure("regularized tvd slice")
 plt.imshow(img_regularized_tvd[100, :, :])
 plt.figure("regularized H1 slice")

--- a/examples/regularization.py
+++ b/examples/regularization.py
@@ -6,27 +6,49 @@ import numpy as np
 import darsia
 
 # Load 3D image
-image_folder = f"{os.path.dirname(__file__)}/images/"
+# image_folder = f"{os.path.dirname(__file__)}/images/"
+image_folder = "C:/Users/erst/src/image_analysis/images/"
 img_path = image_folder + "dicom_3d.npy"
-img = darsia.imread(img_path, dimensions=[0.1, 0.1, 0.1])
+img = darsia.imread(img_path, dimensions=[0.1, 0.1, 0.1], dim=3)
+
+print("Image shape: ", img.img.shape)
 
 # Make regularization parameter heterogenous (for illustration purposes)
+mu_physical = 4.7e-4 * np.ones_like(img.img)
+mu_physical[:, 0:100, :] = 0.5 * 4.7e-4
+
+mu_physical = 4.7e-4
+
 mu = np.ones_like(img.img)
 mu[:, 0:100, :] = 0.5
 
 # Regularize image using anisotropic tvd
-img_regularized_tvd = darsia.tvd(
+img_regularized_physical_tvd = darsia.tvd(
     img=img,
+    method="heterogeneous bregman",
+    isotropic=False,
+    weight=mu_physical,
+    omega=0.1,
+    max_num_iter=30,
+    eps=1e-4,
+    dim=3,
+    verbose=True,
+    solver=darsia.Jacobi(maxiter=20),
+    # solver=darsia.CG(maxiter=20, tol=1e-3),
+)
+
+img_regularized_tvd = darsia.tvd(
+    img=img.img,
     method="heterogeneous bregman",
     isotropic=False,
     weight=mu,
     omega=0.1,
     max_num_iter=30,
-    eps=1e-6,
+    eps=1e-4,
     dim=3,
     verbose=True,
-    solver=darsia.Jacobi(maxiter=20),
-    # solver = darsia.CG(maxiter = 20, tol = 1e-3)
+    # solver=darsia.Jacobi(maxiter=20),
+    solver=darsia.CG(maxiter=20, tol=1e-3),
 )
 
 # Regularize image using H1 regularization
@@ -35,14 +57,16 @@ img_regularized_h1 = darsia.H1_regularization(
     mu=1,
     omega=1,
     dim=3,
-    solver=darsia.Jacobi(maxiter=30, tol=1e-6, verbose=True),
+    solver=darsia.Jacobi(maxiter=30, tol=1e-4, verbose=True),
     # solver = darsia.MG(3)
 )
 
 plt.figure("img slice")
 plt.imshow(img.img[100, :, :])
+plt.figure("regularized physical tvd slice")
+plt.imshow(img_regularized_physical_tvd.img[100, :, :])
 plt.figure("regularized tvd slice")
-plt.imshow(img_regularized_tvd.img[100, :, :])
+plt.imshow(img_regularized_tvd[100, :, :])
 plt.figure("regularized H1 slice")
-plt.imshow(img_regularized_H1.img[100, :, :])
+plt.imshow(img_regularized_h1.img[100, :, :])
 plt.show()

--- a/src/darsia/restoration/tvd.py
+++ b/src/darsia/restoration/tvd.py
@@ -125,7 +125,18 @@ class TVD:
 
         """
         img_copy = img.copy()
-        img_copy.img = self._tvd_array(img.img)
+        if self.method == "heterogeneous bregman":
+            img_copy.img = darsia.split_bregman_tvd(
+                img,
+                mu=self.weight,
+                omega=self.omega,
+                ell=self.regularization,
+                max_num_iter=self.max_num_iter,
+                eps=self.eps,
+                **self.kwargs,
+            )
+        else:
+            img_copy.img = self._tvd_array(img.img)
         return img_copy
 
 

--- a/src/darsia/restoration/tvd.py
+++ b/src/darsia/restoration/tvd.py
@@ -125,18 +125,7 @@ class TVD:
 
         """
         img_copy = img.copy()
-        if self.method == "heterogeneous bregman":
-            img_copy.img = darsia.split_bregman_tvd(
-                img,
-                mu=self.weight,
-                omega=self.omega,
-                ell=self.regularization,
-                max_num_iter=self.max_num_iter,
-                eps=self.eps,
-                **self.kwargs,
-            )
-        else:
-            img_copy.img = self._tvd_array(img.img)
+        img_copy.img = self._tvd_array(img.img)
         return img_copy
 
 

--- a/src/darsia/utils/derivatives.py
+++ b/src/darsia/utils/derivatives.py
@@ -13,7 +13,7 @@ import darsia as da
 
 
 def backward_diff(
-    img: np.ndarray, axis: int, dim: int = 2, h: Optional[float] = None
+    img: np.ndarray, axis: int, dim: int = 2, h: Optional[Union[float, list]] = None
 ) -> np.ndarray:
     """Backward difference of image matrix in direction of axis.
 
@@ -31,13 +31,16 @@ def backward_diff(
     if h is None:
         return np.diff(img, axis=axis, append=da.array_slice(img, axis, -1, None, 1))
     else:
+        if isinstance(h, list):
+            assert len(h) == dim, "h must be a list of length dim"
+            h = h[axis]
         return (
             np.diff(img, axis=axis, append=da.array_slice(img, axis, -1, None, 1)) / h
         )
 
 
 def forward_diff(
-    img: np.ndarray, axis: int, dim: int = 2, h: Optional[float] = None
+    img: np.ndarray, axis: int, dim: int = 2, h: Optional[Union[float, list]] = None
 ) -> np.ndarray:
     """Forward difference of image matrix in direction of axis.
 
@@ -45,7 +48,7 @@ def forward_diff(
         img (np.ndarray): image array
         axis (int): axis along which the difference is taken
         dim (int): dimension of image array
-        h (Optional[float]): grid spacing
+        h (Optional[float, list]): grid spacing
 
     Returns:
         np.ndarray: forward difference image matrix
@@ -55,6 +58,9 @@ def forward_diff(
     if h is None:
         return np.diff(img, axis=axis, prepend=da.array_slice(img, axis, 0, 1, 1))
     else:
+        if isinstance(h, list):
+            assert len(h) == dim, "h must be a list of length dim"
+            h = h[axis]
         return np.diff(img, axis=axis, prepend=da.array_slice(img, axis, 0, 1, 1)) / h
 
 
@@ -62,7 +68,7 @@ def laplace(
     img: np.ndarray,
     axis: Optional[int] = None,
     dim: int = 2,
-    h: Optional[float] = None,
+    h: Optional[Union[float, list]] = None,
     diffusion_coeff: Union[np.ndarray, float] = 1,
 ) -> np.ndarray:
     """Laplace operator with homogeneous boundary conditions.
@@ -73,7 +79,7 @@ def laplace(
         img (np.ndarray): image array
         axis (int): axis along which the difference is taken
         dim (int): dimension of image array
-        h (Optional[float]): grid spacing
+        h (Optional[float, list]): grid spacing
         diffision_coeff (Optional[np.ndarray]): diffusion coefficient
 
     Returns:

--- a/src/darsia/utils/linear_solvers/cg.py
+++ b/src/darsia/utils/linear_solvers/cg.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
 import scipy.sparse as sps
@@ -14,7 +14,7 @@ class CG(da.Solver):
     """
 
     def __call__(
-        self, x0: np.ndarray, rhs: np.ndarray, h: Optional[float] = None
+        self, x0: np.ndarray, rhs: np.ndarray, h: Optional[Union[float, list]] = None
     ) -> np.ndarray:
         """Solve the problem.
 

--- a/src/darsia/utils/linear_solvers/solver.py
+++ b/src/darsia/utils/linear_solvers/solver.py
@@ -58,12 +58,15 @@ class Solver:
         )
 
     @abc.abstractmethod
-    def __call__(self, x0: np.ndarray, rhs: np.ndarray) -> np.ndarray:
+    def __call__(
+        self, x0: np.ndarray, rhs: np.ndarray, h: Optional[Union[float, list]] = None
+    ) -> np.ndarray:
         """Main method of the solver - run the solver.
 
         Args:
             x0 (np.ndarray): initial guess
             rhs (np.ndarray): right hand side
+            h (float or list, optional): voxel size
 
         Returns:
             np.ndarray: solution


### PR DESCRIPTION
Added functionality to take physical derivatives and moved also included in the jacobi and cg solvers. However, it seemed to work poorly when tested with the tvd. It might be because the scaling in the linear system that is solved for the tvd gets off when the laplace term suddenly gets huge compared to the mass term. I guess that there in a heat equation setting normally would be some sort of cfl condition for the step size parameter here (but we don't have that). It could also be that I made a mistake somewhere and therefore it did not work. Nevertheless, I don't have more time to work on this for the coming weeks, so I removed it from the TVD and made a PR with the other changes. 

It is now possible to prescribe different regularization parameters for the different directions when doing tvd (see example). 

Sidenote: I do wonder if my placement of mu in the tvd-algorithm is suboptimal, and makes things converge slower than necessary. What I mean is that I could have substituted \mu\nabla g instead of just \nabla g when splitting the minimization problem. I'll have this in the back of my head and perhaps I'll try the other way arond later. 