### PR TITLE
Allow CurvatureCorrection to define metadata.

### DIFF
--- a/src/darsia/corrections/basecorrection.py
+++ b/src/darsia/corrections/basecorrection.py
@@ -69,13 +69,20 @@ class BaseCorrection(ABC):
                 # Apply transformation to single image
                 img = self.correct_array(img)
 
+            # Apply corrections to metadata
+            meta_update = (
+                self.correct_metadata() if hasattr(self, "correct_metadata") else {}
+            )
+
             if overwrite:
                 # Overwrite original image
                 image.img = img
+                image.update_metadata(meta_update)
                 return image
             else:
                 # Return corrected copy of image
                 meta = image.metadata()
+                meta.update(meta_update)
                 return type(image)(img, **meta)
 
     @abstractmethod

--- a/src/darsia/corrections/shape/curvature.py
+++ b/src/darsia/corrections/shape/curvature.py
@@ -767,12 +767,10 @@ class CurvatureCorrection(darsia.BaseCorrection):
             if all([key in self.config["crop"] for key in ["width", "height"]]):
                 # NOTE: Dimensions of Image uses matrix convention, i.e. (rows, cols).
                 dimensions = [
-                    self.config["crop"][key]
-                    for key in [
-                        "height",
-                        "width",
-                    ]
+                    self.config["crop"]["height"],
+                    self.config["crop"]["width"],
                 ]
                 meta["dimensions"] = dimensions
+                meta["origin"] = [0, self.config["crop"]["height"]]
 
         return meta

--- a/src/darsia/corrections/shape/curvature.py
+++ b/src/darsia/corrections/shape/curvature.py
@@ -150,7 +150,6 @@ class CurvatureCorrection(darsia.BaseCorrection):
             path (Path): path to the json-file.
         """
         with open(str(path), "r") as openfile:
-
             self.config = json.load(openfile)
 
     def return_image(self) -> darsia.Image:
@@ -518,7 +517,6 @@ class CurvatureCorrection(darsia.BaseCorrection):
                 np.save(self.cache_path, self.cache)
 
         elif self.use_cache and self.cache_path.exists():
-
             # Reache cache from file
             self.cache = np.load(self.cache_path, allow_pickle=True).item()
 
@@ -752,3 +750,29 @@ class CurvatureCorrection(darsia.BaseCorrection):
             corrected_img[:, :, i] = im_array_as_vector.reshape(shape).astype(img.dtype)
 
         return np.squeeze(corrected_img)
+
+    def correct_metadata(self) -> dict:
+        """Extract metadata from the config file.
+
+        Returns:
+            dict: metadata
+
+        """
+        # Initialize metadata
+        meta = {}
+
+        # Read physical dimensions from config file
+        if "crop" in self.config:
+            # Update the metadata
+            if all([key in self.config["crop"] for key in ["width", "height"]]):
+                # NOTE: Dimensions of Image uses matrix convention, i.e. (rows, cols).
+                dimensions = [
+                    self.config["crop"][key]
+                    for key in [
+                        "height",
+                        "width",
+                    ]
+                ]
+                meta["dimensions"] = dimensions
+
+        return meta

--- a/src/darsia/image/arithmetics.py
+++ b/src/darsia/image/arithmetics.py
@@ -149,7 +149,7 @@ def superpose(images: list[darsia.Image]) -> darsia.Image:
     dimensions = [cartesian_dimensions[i] for i in to_matrix_indexing]
 
     meta = {
-        "dim": space_dim,
+        "space_dim": space_dim,
         "indexing": indexing,
         "dimensions": dimensions,
         "origin": origin,

--- a/src/darsia/image/coordinatesystem.py
+++ b/src/darsia/image/coordinatesystem.py
@@ -246,7 +246,7 @@ def check_equal_coordinatesystems(
         failure_log.append("indexing")
 
     if not (coordinatesystem1.dim == coordinatesystem2.dim):
-        failure_log.append("dim")
+        failure_log.append("space_dim")
 
     if not exclude_size:
         if not (np.allclose(coordinatesystem1.shape, coordinatesystem2.shape)):

--- a/src/darsia/image/image.py
+++ b/src/darsia/image/image.py
@@ -84,7 +84,7 @@ class Image:
         """Original dtype at construction of the object."""
 
         # ! ---- Spatial meta information
-        self.space_dim: int = kwargs.get("dim", 2)
+        self.space_dim: int = kwargs.get("space_dim", 2)
         """Dimension of the spatial domain."""
 
         self.space_num: int = np.prod(self.shape[: self.space_dim])
@@ -417,7 +417,7 @@ class Image:
 
         """
         metadata = {
-            "dim": self.space_dim,
+            "space_dim": self.space_dim,
             "indexing": self.indexing,
             "dimensions": self.dimensions,
             "origin": self.origin,
@@ -1499,11 +1499,11 @@ class OpticalImage(Image):
         """
         # Define metadata specific for optical images
         optical_metadata = {
-            "dim": 2,
+            "space_dim": 2,
             "indexing": "ij",
             "scalar": False,
         }
-        kwargs.pop("dim", None)
+        kwargs.pop("space_dim", None)
         kwargs.pop("indexing", None)
         kwargs.pop("scalar", None)
 

--- a/src/darsia/image/image.py
+++ b/src/darsia/image/image.py
@@ -371,6 +371,21 @@ class Image:
         # Update relative time
         self.set_time(time)
 
+    def update_metadata(self, meta: Optional[dict] = None, **kwargs) -> None:
+        """Update metadata of image.
+
+        Args:
+            meta (dict): metadata to be updated, with keys corresponding to
+                self.metadata().
+            **kwargs: additional keyword arguments to be updated.
+
+        """
+        if meta is not None:
+            for key, value in meta.items():
+                setattr(self, key, value)
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
     # ! ---- Transformations
 
     def resize(self, cx: float, cy: Optional[float] = None) -> None:

--- a/src/darsia/image/imread.py
+++ b/src/darsia/image/imread.py
@@ -439,7 +439,7 @@ def imread_from_dicom(
     # Collect all meta information for a space time image
     dimensions = [voxel_size[i] * shape[i] for i in range(dim)]
     meta = {
-        "name": series_description[0],
+        # "name": series_description[0],
         "space_dim": dim,
         "indexing": "ijk"[:dim],
         "dimensions": dimensions,

--- a/src/darsia/image/imread.py
+++ b/src/darsia/image/imread.py
@@ -439,7 +439,8 @@ def imread_from_dicom(
     # Collect all meta information for a space time image
     dimensions = [voxel_size[i] * shape[i] for i in range(dim)]
     meta = {
-        "dim": dim,
+        "name": series_description[0],
+        "space_dim": dim,
         "indexing": "ijk"[:dim],
         "dimensions": dimensions,
         "series": series,
@@ -493,7 +494,7 @@ def imread_from_vtu(
 
         # Create a space-time optical image through stacking along the time axis
         meta = data_collection[0][1]  # NOTE: No safety check
-        dim = meta["dim"]
+        dim = meta["space_dim"]
         data = np.stack([d[0] for d in data_collection], axis=dim)
 
         # Fix metadata
@@ -571,7 +572,7 @@ def _read_single_vtu_image(
 
     # Collect all metadata
     meta = {
-        "dim": dim,
+        "space_dim": dim,
         "indexing": indexing,
         "dimensions": dimensions,
         "origin": origin,
@@ -609,7 +610,7 @@ def _resample_data(
 
     """
     # Fetch meta data
-    dim = meta["dim"]
+    dim = meta["space_dim"]
     indexing = meta["indexing"]
 
     # Problem size
@@ -730,7 +731,7 @@ def _embed_data(
 
     """
     # Fetch meta data
-    dim = meta["dim"]
+    dim = meta["space_dim"]
     if dim != 2:
         raise NotImplementedError
     indexing = meta["indexing"]

--- a/src/darsia/signals/reduction/dimensionreduction.py
+++ b/src/darsia/signals/reduction/dimensionreduction.py
@@ -129,7 +129,7 @@ class AxisReduction:
 
         # Fetch and adapt metadata
         metadata = img.metadata()
-        metadata["dim"] = new_dim
+        metadata["space_dim"] = new_dim
         metadata["indexing"] = new_indexing
         metadata["origin"] = new_origin
         metadata["dimensions"] = new_dimensions
@@ -182,8 +182,8 @@ def extrude_along_axis(img: darsia.Image, height: float, num: int) -> darsia.Ima
 
     # Update metadata
     meta = img.metadata()
-    assert meta["dim"] == 2
-    meta["dim"] = 3
+    assert meta["space_dim"] == 2
+    meta["space_dim"] = 3
     meta["dimensions"] = [height, *meta["dimensions"]]
     meta["indexing"] = "ijk"
     meta["origin"] = [height, *meta["origin"]]

--- a/tests/unit/test_arithmetics.py
+++ b/tests/unit/test_arithmetics.py
@@ -9,7 +9,7 @@ import darsia
 
 def test_scalar_weight_3d():
 
-    image = darsia.Image(np.ones((3, 4, 5), dtype=float), dim=3)
+    image = darsia.Image(np.ones((3, 4, 5), dtype=float), space_dim=3)
     weight = 2.0
     weighted_image = darsia.weight(image, weight)
     assert np.allclose(weighted_image.img, 2 * np.ones((3, 4, 5)))
@@ -17,16 +17,16 @@ def test_scalar_weight_3d():
 
 def test_array_weight_2d():
 
-    image = darsia.Image(np.ones((3, 4), dtype=float), dim=2)
-    weight = darsia.Image(np.random.rand(3, 4), dim=2)
+    image = darsia.Image(np.ones((3, 4), dtype=float), space_dim=2)
+    weight = darsia.Image(np.random.rand(3, 4), space_dim=2)
     weighted_image = darsia.weight(image, weight)
     assert np.allclose(weighted_image.img, weight.img)
 
 
 def test_incompatible_weight_2d():
 
-    image = darsia.Image(np.ones((6, 8), dtype=float), dim=2, dimensions=[6, 8])
-    weight = darsia.Image(2 * np.ones((3, 4)), dim=2, dimensions=[6, 8])
+    image = darsia.Image(np.ones((6, 8), dtype=float), space_dim=2, dimensions=[6, 8])
+    weight = darsia.Image(2 * np.ones((3, 4)), space_dim=2, dimensions=[6, 8])
 
     weighted_image = darsia.weight(image, weight)
     assert np.allclose(weighted_image.img, 2 * np.ones((6, 8)))
@@ -34,17 +34,17 @@ def test_incompatible_weight_2d():
 
 def test_array_weight_3d():
 
-    image = darsia.Image(np.ones((3, 4, 5), dtype=float), dim=3)
-    weight = darsia.Image(np.random.rand(3, 4, 5), dim=3)
+    image = darsia.Image(np.ones((3, 4, 5), dtype=float), space_dim=3)
+    weight = darsia.Image(np.random.rand(3, 4, 5), space_dim=3)
     weighted_image = darsia.weight(image, weight)
     assert np.allclose(weighted_image.img, weight.img)
 
 
 def test_superposition_2d():
 
-    image1 = darsia.ScalarImage(np.ones((3, 4), dtype=float), dim=2)
-    image2 = darsia.ScalarImage(2 * np.ones((3, 4), dtype=float), dim=2)
-    image3 = darsia.ScalarImage(3 * np.ones((3, 4), dtype=float), dim=2)
+    image1 = darsia.ScalarImage(np.ones((3, 4), dtype=float), space_dim=2)
+    image2 = darsia.ScalarImage(2 * np.ones((3, 4), dtype=float), space_dim=2)
+    image3 = darsia.ScalarImage(3 * np.ones((3, 4), dtype=float), space_dim=2)
     superposed_image = darsia.superpose([image1, image2, image3])
     assert np.allclose(superposed_image.img, 6 * np.ones((3, 4)))
 

--- a/tests/unit/test_arithmetics.py
+++ b/tests/unit/test_arithmetics.py
@@ -52,7 +52,7 @@ def test_superposition_2d():
 def test_superposition_2d_spacetime():
 
     meta = {
-        "dim": 2,
+        "space_dim": 2,
         "series": True,
         "time": [0, 1, 2, 3, 4],
     }

--- a/tests/unit/test_correction.py
+++ b/tests/unit/test_correction.py
@@ -24,7 +24,7 @@ def read_test_image(img_id: str) -> tuple[np.ndarray, dict]:
 
     # ! ---- Define some metadata corresponding to the input array
     info = {
-        "dim": 2,
+        "space_dim": 2,
         "indexing": "ij",
     }
 
@@ -148,7 +148,7 @@ def test_rotation():
     img_array[4:6, 2:8] = 1
 
     info = {
-        "dim": 2,
+        "space_dim": 2,
         "indexing": "ij",
     }
 

--- a/tests/unit/test_dimension_reduction.py
+++ b/tests/unit/test_dimension_reduction.py
@@ -12,14 +12,14 @@ def test_axis_averaging_x():
 
     image_3d = darsia.Image(
         np.ones((3, 4, 5), dtype=float),
-        dim=3,
+        space_dim=3,
         dimensions=[2, 3, 4],
         series=False,
         scalar=True,
     )
 
-    averaging_axis = darsia.AxisReduction(axis="x", dim=3, mode = "sum")
-    averaging_index = darsia.AxisReduction(axis=2, dim=3, mode = "sum")
+    averaging_axis = darsia.AxisReduction(axis="x", dim=3, mode="sum")
+    averaging_index = darsia.AxisReduction(axis=2, dim=3, mode="sum")
 
     image_2d_via_axis = averaging_axis(image_3d)
     image_2d_via_index = averaging_index(image_3d)
@@ -39,14 +39,14 @@ def test_axis_averaging_y():
 
     image_3d = darsia.Image(
         np.ones((3, 4, 5), dtype=float),
-        dim=3,
+        space_dim=3,
         dimensions=[2, 3, 4],
         series=False,
         scalar=True,
     )
 
-    averaging_axis = darsia.AxisReduction(axis="y", dim=3, mode = "sum")
-    averaging_index = darsia.AxisReduction(axis=1, dim=3, mode = "sum")
+    averaging_axis = darsia.AxisReduction(axis="y", dim=3, mode="sum")
+    averaging_index = darsia.AxisReduction(axis=1, dim=3, mode="sum")
 
     image_2d_via_axis = averaging_axis(image_3d)
     image_2d_via_index = averaging_index(image_3d)
@@ -66,14 +66,14 @@ def test_axis_averaging_z():
 
     image_3d = darsia.Image(
         np.ones((3, 4, 5), dtype=float),
-        dim=3,
+        space_dim=3,
         dimensions=[2, 3, 4],
         series=False,
         scalar=True,
     )
 
-    averaging_axis = darsia.AxisReduction(axis="z", dim=3, mode = "sum")
-    averaging_index = darsia.AxisReduction(axis=0, dim=3, mode = "sum")
+    averaging_axis = darsia.AxisReduction(axis="z", dim=3, mode="sum")
+    averaging_index = darsia.AxisReduction(axis=0, dim=3, mode="sum")
 
     image_2d_via_axis = averaging_axis(image_3d)
     image_2d_via_index = averaging_index(image_3d)
@@ -96,15 +96,15 @@ def test_axis_averaging_series_x():
 
     image_3d = darsia.Image(
         np.ones((3, 4, 5, 6), dtype=float),
-        dim=3,
+        space_dim=3,
         dimensions=[2, 3, 4],
         series=True,
         scalar=True,
         time=[0, 1, 2, 3, 4, 5],
     )
 
-    averaging_axis = darsia.AxisReduction(axis="x", dim=3, mode = "sum")
-    averaging_index = darsia.AxisReduction(axis=2, dim=3, mode = "sum")
+    averaging_axis = darsia.AxisReduction(axis="x", dim=3, mode="sum")
+    averaging_index = darsia.AxisReduction(axis=2, dim=3, mode="sum")
 
     image_2d_via_axis = averaging_axis(image_3d)
     image_2d_via_index = averaging_index(image_3d)

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -39,7 +39,7 @@ def test_initialize_general_image():
     info = {
         "scalar": False,
         "series": False,
-        "dim": 2,
+        "space_dim": 2,
         "indexing": "ij",
         "dimensions": [1.5, 2.8],
     }
@@ -70,7 +70,7 @@ def test_initialize_optical_image():
     info = {
         "series": False,
         "scalar": False,
-        "dim": 2,
+        "space_dim": 2,
         "indexing": "ij",
         "dimensions": [1.5, 2.8],
     }

--- a/tests/unit/test_image_registration.py
+++ b/tests/unit/test_image_registration.py
@@ -30,7 +30,7 @@ def read_test_image(img_id: str) -> tuple[Optional[np.ndarray], Optional[dict], 
 
         # ! ---- Define some metadata corresponding to the input array
         info = {
-            "dim": 2,
+            "space_dim": 2,
             "orientation": "ij",
         }
 

--- a/tests/unit/test_subregion.py
+++ b/tests/unit/test_subregion.py
@@ -12,7 +12,7 @@ def test_time_interval_scalar_image_2d():
 
     # Construct space-time image
     meta = {
-        "dim": 2,
+        "space_dim": 2,
         "series": True,
         "time": [0, 1, 2, 3, 4],
     }
@@ -37,7 +37,7 @@ def test_time_interval_scalar_image_2d_reset_time():
 
     # Construct space-time image
     meta = {
-        "dim": 2,
+        "space_dim": 2,
         "series": True,
         "time": [0, 1, 2, 3, 4],
     }
@@ -63,7 +63,7 @@ def test_time_interval_advanced():
 
     # Construct space-time image
     meta = {
-        "dim": 3,
+        "space_dim": 3,
         "series": True,
         "scalar": False,
         "time": [0, 1, 2, 3, 4],

--- a/tests/unit/test_wasserstein.py
+++ b/tests/unit/test_wasserstein.py
@@ -12,7 +12,7 @@ rows = 10
 cols = rows
 src_square_2d = np.zeros((rows, cols), dtype=float)
 src_square_2d[2:5, 2:5] = 1
-meta_2d = {"width": 1, "height": 1, "dim": 2, "scalar": True}
+meta_2d = {"width": 1, "height": 1, "space_dim": 2, "scalar": True}
 src_image_2d = darsia.Image(src_square_2d, **meta_2d)
 
 # Coarse dst image
@@ -36,7 +36,7 @@ true_distance_2d = 0.379543951823
 pages = 1
 src_square_3d = np.zeros((rows, cols, pages), dtype=float)
 src_square_3d[2:5, 2:5, 0] = 1
-meta_3d = {"dimensions": [1, 1, 1], "dim": 3, "series": False, "scalar": True}
+meta_3d = {"dimensions": [1, 1, 1], "space_dim": 3, "series": False, "scalar": True}
 src_image_3d = darsia.Image(src_square_3d, **meta_3d)
 
 # Coarse dst image


### PR DESCRIPTION
Currently, CurvatureCorrection does hold geometrical information, but does not forward these to the Image objects. This PR adds this functionality. Now, width and height, if defined through CurvatureCorrection are used to redefine the physical dimensions of an Image.