### PR TITLE
Fix flip vectors in vtk

### DIFF
--- a/src/darsia/measure/wasserstein.py
+++ b/src/darsia/measure/wasserstein.py
@@ -1723,6 +1723,4 @@ def wasserstein_distance_to_vtk(
         (key, info[key])
         for key in ["src", "dst", "mass_diff", "flux", "pressure", "transport_density"]
     ]
-    print(type(info["src"]))
-    print(isinstance(info["src"], darsia.Image))
     darsia.plotting.to_vtk(path, data)

--- a/src/darsia/utils/plotting.py
+++ b/src/darsia/utils/plotting.py
@@ -209,7 +209,13 @@ def to_vtk(
                 while len(img) < 3:
                     img.append(np.zeros(target_shape))
                 assert len(img) == 3, "pyevtk only allows 3 components"
-                img = tuple(img)
+                # Flip the directions as part of the conversion
+                if image.space_dim == 1:
+                    img = tuple(img)
+                elif image.space_dim == 2:
+                    img = (img[1], img[0], img[2])
+                elif image.space_dim == 3:
+                    img = (img[1], img[2], img[0])
             cellData[name] = img
 
         # Write to VTK


### PR DESCRIPTION
Use correct order of components in vector data when exported to vtk