### PR TITLE
Initialization of interpolation in resize missing

### DIFF
--- a/src/darsia/restoration/resize.py
+++ b/src/darsia/restoration/resize.py
@@ -74,7 +74,7 @@ class Resize:
         interpolation_pre = (
             kwargs.get(key + "resize interpolation", None)
             if interpolation is None
-            else None
+            else interpolation
         )
         if interpolation_pre is None:
             self.interpolation = None


### PR DESCRIPTION
The input argument did not get passed through. Now this is corrected.