### PR TITLE
Simplify drift correction

### DIFF
--- a/examples/image_registration.py
+++ b/examples/image_registration.py
@@ -41,7 +41,7 @@ curvature_correction = darsia.CurvatureCorrection(config)
 # Setup drift correction taking care of moving camera in between taking photos.
 # Use the color checker as reference in both images, and make the src image
 # the anker.
-roi = (slice(0, 600), slice(0, 600))
+roi = darsia.make_voxel([[0, 0], [600, 600]])
 drift_correction = darsia.DriftCorrection(base=array_src, config={"roi": roi})
 
 # Create darsia images with integrated cropping. Note: the drift correction

--- a/src/darsia/utils/box.py
+++ b/src/darsia/utils/box.py
@@ -6,7 +6,7 @@ import numpy as np
 
 
 def bounding_box(
-    coords: np.ndarray, padding: int = 0, max_size: Optional[list] = None
+    coords: np.ndarray, padding: int = 0, max_size: Optional[Union[list, tuple]] = None
 ) -> tuple[slice, ...]:
     """
     Determine bounding box for a set of given coordinates.
@@ -16,8 +16,7 @@ def bounding_box(
         padding (int): padding to create a slightly larger bounding box. Might
             be of interest if the area that is prescribed in coords cover slightly less than
             strictly needed. Default is 0.
-        max_size (Optional[list]): max size of bounding box.
-            Provided as list with max size in each dimension.
+        max_size (list or tuple, optional): max size of bounding box in each dimension.
 
     Returns:
         tuple of slices: slices with ranges from min to max value

--- a/tests/unit/test_correction.py
+++ b/tests/unit/test_correction.py
@@ -122,7 +122,7 @@ def test_drift_correction():
     original_image = darsia.Image(img=original_array, **info)
 
     # ! ---- Define drift correction
-    roi = (slice(0, 600), slice(0, 600))
+    roi = darsia.make_voxel([[0, 0], [600, 600]])
     drift_correction = darsia.DriftCorrection(base=original_image, config={"roi": roi})
 
     # ! ---- Apply affine transformation

--- a/tests/unit/test_image_registration.py
+++ b/tests/unit/test_image_registration.py
@@ -67,7 +67,7 @@ def test_image_registration():
     # Setup drift correction taking care of moving camera in between taking photos.
     # Use the color checker as reference in both images, and make the src image
     # the anker.
-    roi = (slice(0, 600), slice(0, 600))
+    roi = darsia.make_voxel([[0, 0], [600, 600]])
     drift_correction = darsia.DriftCorrection(base=array_src, config={"roi": roi})
 
     # ! ---- Corrected images


### PR DESCRIPTION
`DriftCorrection` allowed in different ways to provide information on roi to restrict the image during the analysis. Streamlining and restricting to a single use case is provided through this PR.