### PR TITLE
Add base color checker and simplify custom color correction

### DIFF
--- a/examples/co2_and_tracer_analysis.py
+++ b/examples/co2_and_tracer_analysis.py
@@ -22,15 +22,17 @@ with open(image_folder + "config.json", "r") as openfile:
 curvature_correction = darsia.CurvatureCorrection(config=config["curvature"])
 
 # Define color correction object
-roi_cc = np.array(
-    [
-        [152, 202],
-        [225, 206],
-        [226, 101],
-        [153, 98],
-    ]
-)
-color_correction = darsia.ColorCorrection(roi=roi_cc)
+config = {
+    "roi": darsia.make_voxel(
+        [
+            [152, 202],
+            [225, 206],
+            [226, 101],
+            [153, 98],
+        ]
+    )
+}
+color_correction = darsia.ColorCorrection(config=config)
 
 # !----- Main routine for co2 analysis
 

--- a/examples/color_correction.py
+++ b/examples/color_correction.py
@@ -46,17 +46,19 @@ experimental_corrected_baseline = darsia.Image(
 # closest to the brown swatch. Continue in counter-clockwise direction.
 # NOTE: That this example uses a crudely coarsened image. Thus, the marks
 # are not very obvious. They are small white L's.
-roi_cc = np.array(
-    [
-        [154, 176],
-        [222, 176],
-        [222, 68],
-        [154, 68],
-    ]
-)
+config = {
+    "roi": darsia.make_voxel(
+        [
+            [154, 176],
+            [222, 176],
+            [222, 68],
+            [154, 68],
+        ]
+    )
+}
 color_correction = darsia.ColorCorrection(
-    roi=roi_cc,
-    # verbosity = True,
+    base = uncorrected_baseline,
+    config = config
 )
 
 # NOTE: Setting the flag verbosity to True allows to debug some


### PR DESCRIPTION
Aiming at unifying the input for corrections, the `CustomColorCorrection` has been simplified. As it allows now also colorchecker directly as input under construction, a corresponding base class has been added.