### PR TITLE
Voxel center

### DIFF
--- a/src/darsia/utils/point.py
+++ b/src/darsia/utils/point.py
@@ -255,9 +255,10 @@ def make_voxel_center(
             corresponds to row, second to column, third to depth). Defaults to True.
 
     Returns:
-        Union[VoxelCenter, VoxelCenterArray]: VoxelCenter or VoxelCenterArray variant of point (type depends on
-            input), i.e. if a single point is provided, a VoxelCenter is returned, if a list
-            of points is provided, a VoxelCenterArray is returned.
+        Union[VoxelCenter, VoxelCenterArray]: VoxelCenter or VoxelCenterArray variant
+            of point (type depends on input), i.e. if a single point is provided, a
+            VoxelCenter is returned, if a list of points is provided, a VoxelCenterArray
+            is returned.
 
     """
     pts_array = np.array(pts)

--- a/tests/unit/test_point.py
+++ b/tests/unit/test_point.py
@@ -49,6 +49,28 @@ def test_make_voxel():
     assert np.allclose(voxels, [[1, 2], [3, 4]])
 
 
+def test_make_voxel_center():
+    # Single voxel center - VoxelCenter
+    voxel_center = darsia.VoxelCenter([1, 2])
+    assert isinstance(voxel_center, darsia.VoxelCenter)
+    assert np.allclose(voxel_center, [1.5, 2.5])
+
+    # Single voxel center - make_voxel_center
+    voxel_center = darsia.make_voxel_center([1, 2])
+    assert isinstance(voxel_center, darsia.VoxelCenter)
+    assert np.allclose(voxel_center, [1.5, 2.5])
+
+    # Multiple voxel centers - VoxelCenterArray
+    voxel_centers = darsia.VoxelCenterArray([[1, 2], [3.2, 4.8]])
+    assert isinstance(voxel_centers, darsia.VoxelCenterArray)
+    assert np.allclose(voxel_centers, [[1.5, 2.5], [3.5, 4.5]])
+
+    # Multiple voxel centers - make_voxel_center
+    voxel_centers = darsia.make_voxel_center([[1, 2], [3.2, 4.8]])
+    assert isinstance(voxel_centers, darsia.VoxelCenterArray)
+    assert np.allclose(voxel_centers, [[1.5, 2.5], [3.5, 4.5]])
+
+
 def test_make_voxel_reverse_matrix_indexing():
     # Single voxel - Voxel
     voxel = darsia.Voxel([1, 2], matrix_indexing=False)
@@ -99,6 +121,20 @@ def test_voxelarray_getitem():
         assert isinstance(voxel, darsia.Voxel)
 
 
+def text_voxelcenterarray_getitem():
+    # Define VoxelCenterArray
+    voxel_centers = darsia.VoxelCenterArray([[1, 2], [3, 4]])
+
+    # Getitem - single voxel center
+    voxel_center = voxel_centers[0]
+    assert isinstance(voxel_center, darsia.VoxelCenter)
+    assert np.allclose(voxel_center, [1.5, 2.5])
+
+    # Iterator
+    for voxel_center in voxel_centers:
+        assert isinstance(voxel_center, darsia.VoxelCenter)
+
+
 def test_point_to_coordinate():
     # Define reference image
     image = darsia.Image(
@@ -117,6 +153,12 @@ def test_point_to_coordinate():
     assert isinstance(to_coord, darsia.Coordinate)
     assert np.allclose(to_coord, [0.25, 1 / 3])
 
+    # From VoxelCenter
+    voxel_center = darsia.VoxelCenter([2, 1])
+    to_coord = voxel_center.to_coordinate(image.coordinatesystem)
+    assert isinstance(to_coord, darsia.Coordinate)
+    assert np.allclose(to_coord, [0.375, 1 / 6])
+
 
 def test_point_to_voxel():
     # Define reference image
@@ -132,9 +174,40 @@ def test_point_to_voxel():
 
     # From Voxel
     voxel = darsia.Voxel([2, 1])
-    to_voxel = voxel.to_voxel(image.coordinatesystem)
+    to_voxel = voxel.to_voxel()
     assert isinstance(to_voxel, darsia.Voxel)
     assert np.allclose(to_voxel, [2, 1])
+
+    # From VoxelCenter
+    voxel_center = darsia.VoxelCenter([2, 1])
+    to_voxel = voxel_center.to_voxel()
+    assert isinstance(to_voxel, darsia.Voxel)
+    assert np.allclose(to_voxel, [2, 1])
+
+
+def test_point_to_voxel_center():
+    # Define reference image
+    image = darsia.Image(
+        img=np.zeros((3, 4), dtype=float), dimensions=[1, 1], space_dim=2
+    )
+
+    # From Coordinate
+    coord = darsia.Coordinate([0.6, 0.2])
+    to_voxel_center = coord.to_voxel_center(image.coordinatesystem)
+    assert isinstance(to_voxel_center, darsia.VoxelCenter)
+    assert np.allclose(to_voxel_center, [2.5, 2.5])
+
+    # From Voxel
+    voxel = darsia.Voxel([2, 1])
+    to_voxel_center = voxel.to_voxel_center()
+    assert isinstance(to_voxel_center, darsia.VoxelCenter)
+    assert np.allclose(to_voxel_center, [2.5, 1.5])
+
+    # From VoxelCenter
+    voxel_center = darsia.VoxelCenter([2, 1])
+    to_voxel_center = voxel_center.to_voxel_center()
+    assert isinstance(to_voxel_center, darsia.VoxelCenter)
+    assert np.allclose(to_voxel_center, [2.5, 1.5])
 
 
 def test_point_array_to_coordinate():
@@ -155,6 +228,12 @@ def test_point_array_to_coordinate():
     assert isinstance(to_coords, darsia.CoordinateArray)
     assert np.allclose(to_coords, [[0.25, 1 / 3], [0.75, 2 / 3]])
 
+    # From VoxelCenterArray
+    voxel_centers = darsia.VoxelCenterArray([[2, 1], [1, 3]])
+    to_coords = voxel_centers.to_coordinate(image.coordinatesystem)
+    assert isinstance(to_coords, darsia.CoordinateArray)
+    assert np.allclose(to_coords, [[0.375, 1 / 6], [0.875, 3 / 6]])
+
 
 def test_point_array_to_voxel():
     # Define reference image
@@ -173,3 +252,34 @@ def test_point_array_to_voxel():
     to_voxels = voxels.to_voxel(image.coordinatesystem)
     assert isinstance(to_voxels, darsia.VoxelArray)
     assert np.allclose(to_voxels, [[2, 1], [1, 3]])
+
+    # From VoxelCenterArray
+    voxel_centers = darsia.VoxelCenterArray([[2, 1], [1, 3]])
+    to_voxels = voxel_centers.to_voxel(image.coordinatesystem)
+    assert isinstance(to_voxels, darsia.VoxelArray)
+    assert np.allclose(to_voxels, [[2, 1], [1, 3]])
+
+
+def test_point_array_to_voxel_center():
+    # Define reference image
+    image = darsia.Image(
+        img=np.zeros((3, 4), dtype=float), dimensions=[1, 1], space_dim=2
+    )
+
+    # From CoordinateArray
+    coords = darsia.CoordinateArray([[0.6, 0.2], [0.1, 0.9]])
+    to_voxel_centers = coords.to_voxel_center(image.coordinatesystem)
+    assert isinstance(to_voxel_centers, darsia.VoxelCenterArray)
+    assert np.allclose(to_voxel_centers, [[2.5, 2.5], [0.5, 0.5]])
+
+    # From VoxelArray
+    voxels = darsia.VoxelArray([[2, 1], [1, 3]])
+    to_voxel_centers = voxels.to_voxel_center(image.coordinatesystem)
+    assert isinstance(to_voxel_centers, darsia.VoxelCenterArray)
+    assert np.allclose(to_voxel_centers, [[2.5, 1.5], [1.5, 3.5]])
+
+    # From VoxelCenterArray
+    voxel_centers = darsia.VoxelCenterArray([[2, 1], [1, 3]])
+    to_voxel_centers = voxel_centers.to_voxel_center(image.coordinatesystem)
+    assert isinstance(to_voxel_centers, darsia.VoxelCenterArray)
+    assert np.allclose(to_voxel_centers, [[2.5, 1.5], [1.5, 3.5]])


### PR DESCRIPTION
Shifted voxels (i.e., to the center) are useful for geometric correction routines. For completeness, a dedicated point type is added. Corresponding unit tests are extended to also cover `VoxelCenter.`