### PR TITLE
Flexible subregion

### DIFF
--- a/src/darsia/image/image.py
+++ b/src/darsia/image/image.py
@@ -594,14 +594,15 @@ class Image:
 
     def subregion(
         self,
-        voxels: Optional[tuple[slice]] = None,
-        coordinates: Optional[Union[np.ndarray, list[float]]] = None,
+        voxels: Optional[Union[tuple[slice], darsia.VoxelArray]] = None,
+        coordinates: Optional[darsia.CoordinateArray] = None,
     ) -> Image:
         """Extraction of spatial subregion.
 
         Args:
-            voxels (tuple of slices, optional): voxel intervals in all dimensions.
-            coordinates (array or list, optional): points in space, in Cartesian
+            voxels (tuple of slices or VoxelArray, optional): voxel intervals in all
+                dimensions.
+            coordinates (CoordinateArray, optional): points in space, in Cartesian
                 coordinates, uniquely defining a box, i.e., at least space_dim points.
 
         Returns:
@@ -632,7 +633,16 @@ class Image:
                 )
                 for d in range(self.space_dim)
             )
-
+        elif voxels is not None:
+            # Transform a VoxelArray to tuple fo slices
+            if isinstance(voxels, darsia.VoxelArray):
+                voxels: tuple[slice] = tuple(
+                    slice(
+                        max(0, np.min(voxels[:, d])),
+                        min(np.max(voxels[:, d]), self.num_voxels[d]),
+                    )
+                    for d in range(self.space_dim)
+                )
         assert len(voxels) == self.space_dim
 
         # ! ---- Extract dimensions and new origin from voxels

--- a/src/darsia/image/subregions.py
+++ b/src/darsia/image/subregions.py
@@ -2,7 +2,7 @@
 Module containing auxiliary methods to extract ROIs from darsia Images.
 """
 
-from typing import Literal, Optional
+from typing import Literal, Optional, Union
 
 import cv2
 import numpy as np
@@ -45,7 +45,7 @@ InterpolationOption = Literal["inter_nearest", "inter_linear", "inter_area"]
 
 def extract_quadrilateral_ROI(
     img_src: np.ndarray,
-    pts_src,
+    pts_src: Optional[Union[list, np.ndarray]] = None,
     indexing: IndexingOption = "reverse matrix",
     interpolation: InterpolationOption = "inter_linear",
     **kwargs
@@ -98,8 +98,19 @@ def extract_quadrilateral_ROI(
     # ! ---- Mapping
 
     # Fetch corner points in the provided image
+    if pts_src is None:
+        pts_src = [
+            [0, 0],
+            [original_shape[0], 0],
+            [original_shape[0], original_shape[1]],
+            [0, original_shape[1]],
+        ]
+        if indexing == "reverse matrix":
+            pts_src = np.fliplr(np.array(pts_src))
+
     if isinstance(pts_src, list):
         pts_src = np.array(pts_src)
+
     pts_src = to_reverse_matrix_indexing(pts_src, indexing)
 
     # Assign corner points as destination points if none are provided.


### PR DESCRIPTION
Two updates:
- Allow `VoxelArray` for `subregion`, treated analogously to `CoordinateArray.`
- Allow `None` for `pts_src` in `extract_quadrilateral_ROI` (take full image)