### PR TITLE
Read optical images with given date

### DIFF
--- a/src/darsia/image/imread.py
+++ b/src/darsia/image/imread.py
@@ -134,8 +134,9 @@ def imread_from_optical(
             automatically detected from metadata if 'None'.
         transformations (list of callables): transformations for 2d images.
         keyword arguments:
-            series (bool): flag controlling whether a time series of images
-                is created.
+            date (datetime): custom datetime; otherwise read from metadata
+            color_space (str): custom color space; RGB is assumed otherwise
+            any arguments accepted by Image
 
     Returns:
         OpticalImage (or list of such): converted image, list of such, or

--- a/src/darsia/image/imread.py
+++ b/src/darsia/image/imread.py
@@ -145,18 +145,21 @@ def imread_from_optical(
     # TODO check method for grayscale images. shape of array?
 
     if isinstance(path, Path):
-        # Single image
-
+        # Read single image incl. date from metadata of the image
         array, date = _read_single_optical_image(path)
 
-        # Fix metadata
+        # Use the date only if not provided separately
+        if "date" not in kwargs:
+            kwargs["date"] = date
+
+        # Enhance metadata
         kwargs["series"] = False
-        kwargs["color_space"] = "RGB"
+        if "color_space" not in kwargs:
+            kwargs["color_space"] = "RGB"
 
         # Define image
         image = darsia.OpticalImage(
             img=array,
-            date=date,
             time=time,
             transformations=transformations,
             **kwargs,


### PR DESCRIPTION
Previously, `imread` extracted `datetime` infromation from the metadata of an optical image. Now, it is possible to provide a custom datetime via keyword arguments.