### PR TITLE
Remove deprecated np.int

### DIFF
--- a/src/darsia/corrections/color/colorcheckerfinder.py
+++ b/src/darsia/corrections/color/colorcheckerfinder.py
@@ -61,7 +61,7 @@ def _reorient_colorchecker(
 
     # Determine the centers of the swatches as median of the indices
     expected_swatches_centers = [
-        np.median(indices, axis=-1).astype(np.int)
+        np.median(indices, axis=-1).astype(int)
         for indices in expected_swatch_indices
     ]
 

--- a/src/darsia/utils/andersonacceleration.py
+++ b/src/darsia/utils/andersonacceleration.py
@@ -26,7 +26,7 @@ class AndersonAcceleration:
 
         """
 
-        if isinstance(dimension, np.integer):
+        if isinstance(dimension, int):
             self._dimension: int = dimension
             self._tensor: bool = False
         elif isinstance(dimension, tuple):


### PR DESCRIPTION
Numpy does not support `np.int` anymore. Replace with equivalent `int.`