### PR TITLE
Extended return options for static thresholding

### DIFF
--- a/src/darsia/signals/models/staticthresholdmodel.py
+++ b/src/darsia/signals/models/staticthresholdmodel.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import Optional, Union
 
 import numpy as np
+import skimage
 
 import darsia
 
@@ -22,6 +23,7 @@ class StaticThresholdModel(darsia.Model):
         threshold_lower: Union[float, list[float]] = 0.0,
         threshold_upper: Optional[Union[float, list[float]]] = None,
         labels: Optional[np.ndarray] = None,
+        return_float: bool = False,
     ) -> None:
         """
         Constructor of StaticThresholdModel.
@@ -30,8 +32,10 @@ class StaticThresholdModel(darsia.Model):
             threshold_lower (float or list of float): lower threshold value(s)
             threshold_upper (float or list of float): upper threshold value(s)
             labels (array): labeled domain
+            return_float (bool): flag controlling whether the output is a float or boolean
 
         """
+        self.return_float = return_float
 
         # The argument label decides whether a homogeneous or heterogeneous
         # threatment is considered.
@@ -105,7 +109,10 @@ class StaticThresholdModel(darsia.Model):
 
         # Restrict data to the provided mask
         if mask is None:
-            return threshold_mask
+            if self.return_float:
+                return skimage.img_as_float32(threshold_mask)
+            else:
+                return threshold_mask
         else:
             return np.logical_and(threshold_mask, mask)
 


### PR DESCRIPTION
Static threshold results may be returned as float arrays now.