### PR TITLE
Fix lumped mass matrix for faces.

### DIFF
--- a/src/darsia/utils/fv.py
+++ b/src/darsia/utils/fv.py
@@ -71,13 +71,9 @@ class FVMass:
                 # After all, this is identical to the arithmetic avg of cell volumes
                 # connected to the face. This requires careful handling of the boundary faces.
                 # NOTE: This assumes equidistant grid spacing.
+                # NOTE: Fluxes on boundary are 0 and excluded.
                 volume_scaling = np.ones(grid.num_faces, dtype=float)
-                volume_scaling[grid.exterior_faces] = 0.5
-                mass_matrix = sps.diags(
-                    np.prod(grid.voxel_size)
-                    * volume_scaling
-                    * np.ones(grid.num_faces, dtype=float)
-                )
+                mass_matrix = sps.diags(np.prod(grid.voxel_size) * volume_scaling)
             else:
                 raise NotImplementedError
 

--- a/tests/unit/test_fv.py
+++ b/tests/unit/test_fv.py
@@ -101,7 +101,7 @@ def test_mass_face_2d():
 
     # Check diagonal values
     assert len(np.unique(np.diag(mass))) == 1
-    assert np.isclose(mass[0, 0], 0.5 * 0.125)
+    assert all([np.isclose(mass[i, i], 0.5 * 0.25) for i in range(20)])
 
 
 def test_mass_face_3d():
@@ -116,7 +116,7 @@ def test_mass_face_3d():
 
     # Check diagonal values
     assert len(np.unique(np.diag(mass))) == 1
-    assert np.isclose(mass[0, 0], 0.5 * 0.25)
+    assert all([np.isclose(mass[i, i], 0.5 * 0.25 * 2) for i in range(60)])
 
 
 def test_tangential_reconstruction_2d_1():


### PR DESCRIPTION
The lumped mass matrix for face quantities was computed wrongly. The rationale behind the mass matrix is the lumping of the RT0 mass matrix on Cartesian grids. A careful calculation shows, that what is left is the arithmetic average of the cell volumes of cells to the left and right of each face. It is for now assumed that the grid is equidistant along each axis, such that only the boundary faces need extra care.