### PR TITLE
Improvements in petsc usage

### DIFF
--- a/src/darsia/measure/wasserstein.py
+++ b/src/darsia/measure/wasserstein.py
@@ -15,6 +15,7 @@ import numpy as np
 import pyamg
 import scipy.sparse as sps
 from scipy.stats import hmean
+import petsc4py.PETSc as PETSc
 
 import darsia
 
@@ -320,15 +321,15 @@ class VariationalWassersteinDistance(darsia.EMD):
         ], f"Linear solver {self.linear_solver_type} not supported."
         assert self.formulation in [
             "full",
-            "flux-reduced",
+            "flux_reduced",
             "pressure",
         ], f"Formulation {self.formulation} not supported."
 
-        if self.linear_solver_type == "ksp":
-            if self.formulation == "flux-reduced":
-                raise ValueError(
-                    "KSP solver only supports for full and pressure formulation."
-                )
+        # if self.linear_solver_type == "ksp":
+        #     if self.formulation == "flux_reduced":
+        #         raise ValueError(
+        #             "KSP solver only supports for full and pressure formulation."
+        #         )
 
         # Setup inrastructure for Schur complement reduction
         if self.formulation == "flux_reduced":
@@ -475,7 +476,7 @@ class VariationalWassersteinDistance(darsia.EMD):
         """
         # Define CG solver
         self.linear_solver = darsia.linalg.KSP(
-            matrix, field_ises=field_ises, nullspace=nullspace
+            matrix, field_ises=field_ises, nullspace=nullspace,
         )
 
         # Define solver options
@@ -493,15 +494,28 @@ class VariationalWassersteinDistance(darsia.EMD):
                     "pc_factor_mat_solver_type": "mumps",
                 }
             else:
-                prec = linear_solver_options.get("pc_type", "hypre")
                 self.solver_options = {
                     "ksp_type": approach,
                     # "ksp_monitor_true_residual": None,
                     "ksp_rtol": rtol,
                     "ksp_atol": atol,
                     "ksp_max_it": maxiter,
-                    "pc_type": prec,
+                    "pc_type": "hypre",
                 }
+                if self.grid.dim == 3:
+                    self.solver_options.update({
+                    # tuning parameters for the multigrid
+                    # https://mooseframework.inl.gov/releases/moose/2021-09-15/application_development/hypre.html
+                    "pc_hypre_type": "boomeramg",
+                    "pc_hypre_boomeramg_strong_threshold": 0.7,
+                    "pc_hypre_boomeramg_max_iter": 1,
+                    "pc_hypre_boomeramg_agg_nl": 2,
+                    "pc_hypre_boomeramg_interp_type": "ext+i", # "classic" or "ext+i"
+                    }
+                )
+                # Include other PETSc options passed from the user
+                other_petsc_options = linear_solver_options.get("petsc_options", {})
+                self.solver_options.update(other_petsc_options)
         else:
             if approach == "direct":
                 self.solver_options = {
@@ -992,7 +1006,10 @@ class VariationalWassersteinDistance(darsia.EMD):
 
             # Determine the l2 norm of the fluxes on the faces
             weighted_face_flux = self._product(harm_avg_face_weights, full_face_flux)
-            norm_weighted_face_flux = np.linalg.norm(weighted_face_flux, 2, axis=1)
+            norm_weighted_face_flux = np.maximum(
+                np.linalg.norm(weighted_face_flux, 2, axis=1),
+                self.regularization
+            )
 
             # Combine weights**2 / |weight * flux| on faces
             face_weights = harm_avg_face_weights**2 / norm_weighted_face_flux
@@ -1028,6 +1045,49 @@ class VariationalWassersteinDistance(darsia.EMD):
         )
 
     # ! ---- Solver methods ----
+    def setup_petsc_variables(self, weight: np.ndarray = None):
+        """
+        Instantiate the Petsc variables for the Schur complement
+        """
+        # Setup Petsc operators
+        self.div_petsc = darsia.linalg.numpy_to_petsc(self.div)
+        n = self.grid.num_faces
+        self.weight_laplacian_vec = PETSc.Vec().createSeq(n)
+        if weight is None:
+            self.weight_laplacian_vec.set(1.0)
+        else:
+            self.weight_laplacian_vec.setArray(weight)
+        
+        
+        # THIS DOES NOT WORK in the matrix-matrix multiplication
+        # self.weight_laplacian_matrix = PETSc.Mat().createDiagonal(self.inv_weight_laplacian_vec)
+        # We need to create a matrix and set the diagonal
+        self.weight_laplacian_matrix = PETSc.Mat().createAIJ(
+            size=[n,n], 
+            csr=(np.arange(n + 1, dtype="int32"), 
+                    np.arange(n, dtype="int32"), 
+                    np.zeros(n))
+        )   
+        self.weight_laplacian_matrix.setDiagonal(self.weight_laplacian_vec)
+        
+        # We store also the grad in order to use the matrix-matrix-matrix multiplication
+        self.grad_petsc = self.div_petsc.copy()
+        self.grad_petsc.transpose()
+        
+    
+        # assign
+        self.laplacian_matrix = self.div_petsc.matMatMult(self.weight_laplacian_matrix,self.grad_petsc)
+    
+    def assemble_schur_complement(self, weights: np.ndarray):
+        """
+        Assemble the Schur complement matrix = D^T * W * D
+        in the Petsc matrix self.weight_laplacian_matrix
+        """
+        self.weight_laplacian_vec.setArray(weights)
+        self.weight_laplacian_matrix.setDiagonal(self.weight_laplacian_vec)
+        self.div_petsc.matMatMult(self.weight_laplacian_matrix,self.grad_petsc,result=self.laplacian_matrix)                       
+
+
 
     def linear_solve(
         self,
@@ -1115,13 +1175,21 @@ class VariationalWassersteinDistance(darsia.EMD):
             # Allocate memory for solution
             solution = np.zeros_like(rhs)
 
-            # 1. Reduce flux block
-            (
-                self.reduced_matrix,
-                self.reduced_rhs,
-                self.matrix_flux_inv,
-            ) = self.eliminate_flux(matrix, rhs)
 
+            # 1. Reduce flux block 
+            if self.linear_solver_type == "ksp":
+                self.matrix_flux_inv = sps.diags(1.0 / matrix.diagonal()[self.flux_slice])
+                self.reduced_rhs = rhs[self.pressure_slice].copy()
+                self.reduced_rhs -= self.div.dot(self.matrix_flux_inv.dot(rhs[self.flux_slice]))
+            else:
+                (
+                    self.reduced_matrix,
+                    self.reduced_rhs,
+                    self.matrix_flux_inv,
+                ) = self.eliminate_flux(matrix, rhs)
+
+            
+            
             # 2. Build linear solver for reduced system
             if setup_linear_solver:
                 if self.linear_solver_type == "direct":
@@ -1130,15 +1198,40 @@ class VariationalWassersteinDistance(darsia.EMD):
                     self.setup_amg_solver(self.reduced_matrix)
                 elif self.linear_solver_type == "cg":
                     self.setup_cg_solver(self.reduced_matrix)
+                elif self.linear_solver_type == "ksp":
+                    # Update the Schur complement matrix B^T * A^{-1} * B
+                    weight = 1.0 / matrix.diagonal()[self.flux_slice]
+                    if not hasattr(self, "div_petsc"):
+                        self.setup_petsc_variables(weight = weight)
+                    else:
+                        self.assemble_schur_complement(weights=weight)
+
+                    # Setup KSP solver
+                    if not hasattr(self, "linear_solver"):
+                        kernel = np.ones(self.grid.num_cells)
+                        kernel /= np.linalg.norm(kernel)
+                        self.setup_ksp_solver(self.laplacian_matrix,
+                                               nullspace=[kernel])
+                    else:
+                        # Just update the matrix
+                        self.linear_solver.ksp.setOperators(self.laplacian_matrix)
 
             # Stop timer to measure setup time
             time_setup = time.time() - tic
 
             # 3. Solve for the pressure and lagrange multiplier
             tic = time.time()
-            solution[self.reduced_system_slice] = self.linear_solver.solve(
-                self.reduced_rhs, **self.solver_options
-            )
+            if self.linear_solver_type == "ksp":
+                pot = self.linear_solver.solve(
+                    self.reduced_rhs, **self.solver_options
+                )
+                solution[self.pressure_slice] = pot
+                solution[self.lagrange_multiplier_slice] = 0.0
+            else:
+                solution[self.reduced_system_slice] = self.linear_solver.solve(
+                    self.reduced_rhs, **self.solver_options
+                )
+                
 
             # 4. Compute flux update
             solution[self.flux_slice] = self.compute_flux_update(solution, rhs)
@@ -1174,6 +1267,7 @@ class VariationalWassersteinDistance(darsia.EMD):
                     "Implementation requires solution satisfy the constraint."
                 )
 
+
             # 1. Reduce flux block
             (
                 self.reduced_matrix,
@@ -1189,7 +1283,7 @@ class VariationalWassersteinDistance(darsia.EMD):
                 self.reduced_matrix,
                 self.reduced_rhs,
             )
-
+            
             # 3. Build linear solver for pure pressure system
             if setup_linear_solver:
                 if self.linear_solver_type == "direct":
@@ -1202,19 +1296,16 @@ class VariationalWassersteinDistance(darsia.EMD):
                     self.setup_cg_solver(self.fully_reduced_matrix)
 
                 elif self.linear_solver_type == "ksp":
-                    if not hasattr(self, "linear_solver"):
-                        self.setup_ksp_solver(self.fully_reduced_matrix)
-
-                    if reuse_solver:
-                        self.linear_solver.setup(self.solver_options)
-
-                    # Free memory if solver needs to be re-setup
                     if hasattr(self, "linear_solver"):
                         if not reuse_solver:
                             self.linear_solver.kill()
                             self.setup_ksp_solver(self.fully_reduced_matrix)
                     else:
                         self.setup_ksp_solver(self.fully_reduced_matrix)
+                    
+                    self.linear_solver.setup(self.solver_options)
+                    
+
 
             # Stop timer to measure setup time
             time_setup = time.time() - tic
@@ -1263,7 +1354,7 @@ class VariationalWassersteinDistance(darsia.EMD):
 
         # Gauss eliminiation on matrices
         reduced_jacobian = self.jacobian_subblock + schur_complement
-
+        
         # Gauss elimination on vectors
         reduced_residual = residual[self.reduced_system_slice].copy()
         reduced_residual -= self.D.dot(J_inv.dot(residual[self.flux_slice]))

--- a/src/darsia/utils/linalg.py
+++ b/src/darsia/utils/linalg.py
@@ -39,19 +39,20 @@ try:
         """Convert a numpy matrix to a PETSc matrix."""
         if not sps.isspmatrix_csr(A):
             A = A.tocsr()
-        return PETSc.Mat().createAIJ(
-            size=A.shape, csr=(A.indptr, A.indices, A.data)
-        )
-    
-    def add_diagonal(A: PETSc.Mat, alpha = 0.0) -> None:
+        return PETSc.Mat().createAIJ(size=A.shape, csr=(A.indptr, A.indices, A.data))
+
+    def add_diagonal(A: PETSc.Mat, alpha=0.0) -> None:
         """
         Add a zero diagonal to make the matrix the corresponding entries.
         Operate in place.
         """
         diagonal = PETSc.Mat().createAIJ(
-            size=A.size, csr=(np.arange(A.size[0] + 1, dtype="int32"),
-                               np.arange(A.size[0], dtype="int32"),
-                                alpha * np.ones(A.size[0]))
+            size=A.size,
+            csr=(
+                np.arange(A.size[0] + 1, dtype="int32"),
+                np.arange(A.size[0], dtype="int32"),
+                alpha * np.ones(A.size[0]),
+            ),
         )
         print(alpha)
         A += diagonal
@@ -59,7 +60,7 @@ try:
     class KSP:
         def __init__(
             self,
-            A: Union[sps.csc_matrix,PETSc.Mat],
+            A: Union[sps.csc_matrix, PETSc.Mat],
             field_ises: Optional[
                 list[tuple[str, Union[PETSc.IS, npt.NDArray[np.int32]]]]
             ] = None,
@@ -103,7 +104,7 @@ try:
                 self.A = A
                 # convert to petsc matrix
                 self.A_petsc = numpy_to_petsc(A)
-            elif isinstance(A, PETSc.Mat):  
+            elif isinstance(A, PETSc.Mat):
                 self.A_petsc = A
             else:
                 raise ValueError("A must be a scipy or PETSc matrix")
@@ -242,15 +243,15 @@ try:
             # check if the rhs is orthogonal to the nullspace
             rhs_norm = self.rhs_petsc.norm()
             rtol = self.petsc_options.get("ksp_rtol", 1e-6)
-            for i,k in enumerate(self._petsc_kernels):
-                dot = abs(self.rhs_petsc.dot(k))/rhs_norm
-                if min(dot,rhs_norm) > rtol:
+            for i, k in enumerate(self._petsc_kernels):
+                dot = abs(self.rhs_petsc.dot(k)) / rhs_norm
+                if min(dot, rhs_norm) > rtol:
                     raise ValueError(f"RHS not ortogonal. v_{i}^T rhs= {dot=:2e}")
 
             # solve
             self.sol_petsc.set(0.0)
             self.ksp.solve(self.rhs_petsc, self.sol_petsc)
-            
+
             # check if the solver worked
             reason = self.ksp.getConvergedReason()
             if reason < 0:

--- a/tests/unit/test_wasserstein.py
+++ b/tests/unit/test_wasserstein.py
@@ -138,10 +138,14 @@ ksp_krylov_options = {
     "linear_solver": "ksp",
     "linear_solver_options": {
         "rtol": 1e-8,
-        "approach": "cg",
-        "pc_type": "hypre",
+        "atol": 1e-9,
+        "approach": "gmres",
+        "petsc_options": {
+        #"ksp_view": None,
+            "pc_type": "hypre", 
+        },
     },
-    "formulation": "pressure",
+    "formulation": "flux_reduced",
 }
 
 ksp_block_krylov_options = {
@@ -178,6 +182,7 @@ options = {
     "tol_increment": 1e-6,
     "tol_distance": 1e-10,
     "return_info": True,
+    "regularization": 1e-15,
 }
 
 # ! ---- Tests ----

--- a/tests/unit/test_wasserstein.py
+++ b/tests/unit/test_wasserstein.py
@@ -141,8 +141,8 @@ ksp_krylov_options = {
         "atol": 1e-9,
         "approach": "gmres",
         "petsc_options": {
-        #"ksp_view": None,
-            "pc_type": "hypre", 
+            # "ksp_view": None,
+            "pc_type": "hypre",
         },
     },
     "formulation": "flux_reduced",


### PR DESCRIPTION
- The formulation "flux_reduced" for the solution of linear systems in  the wasserstein.py script is now covered with ksp solvers.

- Tuning of hypre preconditioner is added for 3d case.

- We can now pass extra ksp option using the dict. "petsc_options" in "linear_solver_options":  .

- Using petsc matrices and routined the assembly of the schur complement does not required to convert from scipy to petsc several time.
