### PR TITLE
Fix closing windows during point selection

### DIFF
--- a/src/darsia/assistants/base_assistant.py
+++ b/src/darsia/assistants/base_assistant.py
@@ -27,9 +27,9 @@ class BaseAssistant(ABC):
         """Figure for analysis."""
         self.ax = kwargs.get("ax")
         """Axes for analysis."""
-        assert (self.fig is None) == (
-            self.ax is None
-        ), "Both fig and ax must be None or not None."
+        assert (self.fig is None) == (self.ax is None), (
+            "Both fig and ax must be None or not None."
+        )
         if self.fig is None and self.ax is None:
             self.fig = plt.figure()  # self.name)
             if self.img.space_dim == 2:

--- a/src/darsia/assistants/labels_assistant.py
+++ b/src/darsia/assistants/labels_assistant.py
@@ -1,4 +1,4 @@
-""""Labels assistant built from modules."""
+"""Labels assistant built from modules."""
 
 from typing import Optional
 from warnings import warn
@@ -327,7 +327,6 @@ class LabelsMaskSelectionAssistant:
         mask = np.zeros_like(self.labels.img, dtype=bool)
 
         if points is not None and len(points) > 0:
-
             # Identify corresponding labels
             labels = np.unique([self.labels.img[p[0], p[1]] for p in points])
 
@@ -445,9 +444,9 @@ class LabelsAssistant:
         self.cache_background = None
         """Cache for background image."""
         if labels is None:
-            assert (
-                self.background is not None
-            ), "Background image required to initialize empty labels."
+            assert self.background is not None, (
+                "Background image required to initialize empty labels."
+            )
             self.labels = darsia.Image(
                 np.zeros_like(self.background.img, dtype=int),
                 **self.background.metadata(),

--- a/src/darsia/assistants/point_selection_assistant.py
+++ b/src/darsia/assistants/point_selection_assistant.py
@@ -61,6 +61,8 @@ class PointSelectionAssistant(darsia.BaseAssistant):
                 self._print_info()
 
         # Convert to right format.
+        if hasattr(self, "fig") and self.fig is not None:
+            plt.close(self.fig)
         voxels = darsia.VoxelArray(self.pts)
         if self.return_coordinates:
             return self.img.coordinatesystem.coordinate(voxels)

--- a/src/darsia/corrections/color/illuminationcorrection.py
+++ b/src/darsia/corrections/color/illuminationcorrection.py
@@ -269,7 +269,7 @@ class IlluminationCorrection(darsia.BaseCorrection):
                     va="center",
                     fontsize=5,
                 )
-            plt.savefig(log / "illumination_correction" / "samples.png")
+            plt.savefig(log / "illumination_correction" / "samples.png", dpi=500)
             plt.close()
 
             # Log the before and after scaling in a side-by-side plot
@@ -286,7 +286,7 @@ class IlluminationCorrection(darsia.BaseCorrection):
                 orientation="vertical",
                 fraction=0.05,
             )
-            plt.savefig(log / "illumination_correction" / "scaling.png")
+            plt.savefig(log / "illumination_correction" / "scaling.png", dpi=500)
             plt.close()
 
     def correct_array(self, img: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
With recent versions of matplotlib, the windows after point selection did not close automatically anymore. Close them explicitly now.