### PR TITLE
Robust colorchecker finder

### DIFF
--- a/src/darsia/corrections/color/colorcheckerfinder.py
+++ b/src/darsia/corrections/color/colorcheckerfinder.py
@@ -93,8 +93,12 @@ def _reorient_colorchecker(
     elif np.allclose(closest_swatches, [0, 3]):
         closest_swatches = [0, 1, 2, 3]
     else:
-        raise NotImplementedError(
-            f"Closet swatches {closest_swatches} not implemented."
+        # Hope for the best: Assume "brown" is in the top left corner and
+        # "turquoise" in the top right corner.
+        closest_swatches = [0, 1, 2, 3]
+        warn(
+            """Colorchecker orientation not found. """
+            """Assuming brown in top left and turquoise in top right corner."""
         )
 
     # Arange local voxels such that they follow clock-wise sorting

--- a/src/darsia/corrections/color/illuminationcorrection.py
+++ b/src/darsia/corrections/color/illuminationcorrection.py
@@ -269,7 +269,7 @@ class IlluminationCorrection(darsia.BaseCorrection):
                     va="center",
                     fontsize=5,
                 )
-            plt.savefig(log / "illumination_correction" / "samples.png")
+            plt.savefig(log / "illumination_correction" / "samples.png", dpi=500)
             plt.close()
 
             # Log the before and after scaling in a side-by-side plot
@@ -286,7 +286,7 @@ class IlluminationCorrection(darsia.BaseCorrection):
                 orientation="vertical",
                 fraction=0.05,
             )
-            plt.savefig(log / "illumination_correction" / "scaling.png")
+            plt.savefig(log / "illumination_correction" / "scaling.png", dpi=500)
             plt.close()
 
     def correct_array(self, img: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
In the case of bad light, the colorchecker orientation may be not detectable due to bad color detection. Provide a robust alternative without stopping the code.