### PR TITLE
Add full_like adapting np.full_like for Image

### DIFF
--- a/src/darsia/utils/standard_images.py
+++ b/src/darsia/utils/standard_images.py
@@ -71,7 +71,7 @@ def full_like(
     mode: Literal["shape", "voxels"] = "shape",
     dtype: Optional[StandardDtype] = None,
 ) -> darsia.Image:
-    """Analogon of np.full_like but for darsia.Image objects.
+    """Analog of np.full_like but for darsia.Image objects.
 
     Args:
         image (darsia.Image): input image

--- a/src/darsia/utils/standard_images.py
+++ b/src/darsia/utils/standard_images.py
@@ -14,7 +14,7 @@ def zeros_like(
     mode: Literal["shape", "voxels"] = "shape",
     dtype: Optional[StandardDtype] = None,
 ) -> darsia.Image:
-    """Analogon of np.zeros_like but for darsia.Image objects.
+    """Analog of np.zeros_like but for darsia.Image objects.
 
     Args:
         image (darsia.Image): input image
@@ -42,7 +42,7 @@ def ones_like(
     mode: Literal["shape", "voxels"] = "shape",
     dtype: Optional[StandardDtype] = None,
 ) -> darsia.Image:
-    """Analogon of np.ones_like but for darsia.Image objects.
+    """Analog of np.ones_like but for darsia.Image objects.
 
     Args:
         image (darsia.Image): input image

--- a/src/darsia/utils/standard_images.py
+++ b/src/darsia/utils/standard_images.py
@@ -63,3 +63,34 @@ def ones_like(
         return darsia.ScalarImage(
             np.ones(image.num_voxels, dtype=dtype), **image.metadata()
         )
+
+
+def full_like(
+    image: darsia.Image,
+    fill_value: np.ndarray | float | int,
+    mode: Literal["shape", "voxels"] = "shape",
+    dtype: Optional[StandardDtype] = None,
+) -> darsia.Image:
+    """Analogon of np.full_like but for darsia.Image objects.
+
+    Args:
+        image (darsia.Image): input image
+        fill_value (np.ndarray | float | int): value to fill the output image with
+        mode (Literal["shape", "voxels"], optional): mode of the output image. Defaults to
+            "shape".
+        dtype (Optional[StandardDtype], optional): dtype of the output image. Defaults to None.
+
+    Returns:
+        darsia.Image: output image
+
+    """
+    if dtype is None:
+        dtype = image.dtype
+    if mode == "shape":
+        ImageType = type(image)
+        return ImageType(np.full_like(image.img, fill_value, dtype), **image.metadata())
+    elif mode == "voxels":
+        raise NotImplementedError(
+            """The 'voxels' mode is not implemented for full_like. """
+            """Need to create an Image with correct dimensions based on fill_value."""
+        )


### PR DESCRIPTION
Extend standard images, allowing for fast access setting of new images, instead of using copy and `img` access.