### PR TITLE
Theme selector

### DIFF
--- a/src/darsia/gui/__main__.py
+++ b/src/darsia/gui/__main__.py
@@ -12,11 +12,13 @@ Run the GUI using one of the following methods:
 from PySide6.QtWidgets import QApplication
 
 from .ui.main_window import MainWindow
+from .ui.theme import apply_theme, get_theme
 
 if __name__ == "__main__":
     app = QApplication()
     app.setOrganizationName("DarSIA")
     app.setApplicationName("DarSIA GUI")
+    apply_theme(app, get_theme())
     window = MainWindow()
     window.show()
     app.exec()

--- a/src/darsia/gui/ui/main_window.py
+++ b/src/darsia/gui/ui/main_window.py
@@ -33,7 +33,8 @@ from .menu import MenuBuilder
 from .recent_files import add_recent_config, remove_recent_config
 from .settings import SettingsFactory
 from .setup import SetupTab
-from .theme import apply_theme, set_theme as save_theme
+from .theme import apply_theme
+from .theme import set_theme as save_theme
 from .toolbar import ToolbarBuilder
 from .utils_tab import UtilsTab
 

--- a/src/darsia/gui/ui/main_window.py
+++ b/src/darsia/gui/ui/main_window.py
@@ -33,6 +33,7 @@ from .menu import MenuBuilder
 from .recent_files import add_recent_config, remove_recent_config
 from .settings import SettingsFactory
 from .setup import SetupTab
+from .theme import apply_theme, set_theme as save_theme
 from .toolbar import ToolbarBuilder
 from .utils_tab import UtilsTab
 
@@ -514,6 +515,20 @@ class MainWindow(QMainWindow):
         """Display all fixed-schema sections in the settings panel."""
         all_settings = self.settings_factory.get_all_settings()
         self._render_settings_tabs(all_settings)
+
+    def set_theme(self, mode: str):
+        """Set the application theme (System/Light/Dark).
+
+        Parameters
+        ----------
+        mode : str
+            One of "System", "Light", or "Dark".
+        """
+        from PySide6.QtWidgets import QApplication
+
+        apply_theme(QApplication.instance(), mode)
+        save_theme(mode)
+        self.print_log(f"Theme set to {mode}")
 
     def show_about_dialog(self):
         """Show the About dialog."""

--- a/src/darsia/gui/ui/menu.py
+++ b/src/darsia/gui/ui/menu.py
@@ -56,13 +56,14 @@ class MenuBuilder:
         )
 
         view_menu = menu_bar.addMenu("&View")
+        theme_menu = view_menu.addMenu("Switch &Theme")
         theme_group = QActionGroup(self.main_window)
         theme_group.setExclusive(True)
 
         current_theme = get_theme()
         for theme_name in ["System", "Light", "Dark"]:
             action = self._add_action(
-                view_menu,
+                theme_menu,
                 f"&{theme_name}",
                 partial(self.main_window.set_theme, theme_name),
             )

--- a/src/darsia/gui/ui/menu.py
+++ b/src/darsia/gui/ui/menu.py
@@ -1,8 +1,9 @@
 from functools import partial
 
-from PySide6.QtGui import QAction, QKeySequence
+from PySide6.QtGui import QAction, QActionGroup, QKeySequence
 
 from .recent_files import clear_recent_configs, get_recent_configs
+from .theme import get_theme
 
 
 class MenuBuilder:
@@ -53,6 +54,21 @@ class MenuBuilder:
             self.main_window.display_full_settings,
             "Ctrl+E",
         )
+
+        view_menu = menu_bar.addMenu("&View")
+        theme_group = QActionGroup(self.main_window)
+        theme_group.setExclusive(True)
+
+        current_theme = get_theme()
+        for theme_name in ["System", "Light", "Dark"]:
+            action = self._add_action(
+                view_menu,
+                f"&{theme_name}",
+                partial(self.main_window.set_theme, theme_name),
+            )
+            action.setCheckable(True)
+            action.setChecked(theme_name == current_theme)
+            theme_group.addAction(action)
 
         help_menu = menu_bar.addMenu("&Help")
         self._add_action(help_menu, "&About", self.main_window.show_about_dialog)

--- a/src/darsia/gui/ui/theme.py
+++ b/src/darsia/gui/ui/theme.py
@@ -1,0 +1,108 @@
+"""Theme switcher for Light/Dark/System modes with persistence."""
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QColor, QPalette
+from PySide6.QtCore import QSettings
+
+_original_style = None
+_original_palette = None
+
+
+def apply_theme(app, mode: str) -> None:
+    """Apply a theme (System/Light/Dark) to the application.
+
+    Parameters
+    ----------
+    app : QApplication
+        The application instance to theme.
+    mode : str
+        One of "System", "Light", or "Dark".
+    """
+    global _original_style, _original_palette
+
+    if mode == "System":
+        # Restore original state
+        if _original_style is not None:
+            app.setStyle(_original_style)
+        if _original_palette is not None:
+            app.setPalette(_original_palette)
+        app.styleHints().setColorScheme(Qt.ColorScheme.Unknown)
+    elif mode == "Light":
+        # Save original state on first call
+        if _original_style is None:
+            _original_style = app.style().objectName()
+        if _original_palette is None:
+            _original_palette = app.palette()
+
+        app.setStyle("Fusion")
+        palette = QPalette()
+        palette.setColor(QPalette.Window, QColor(240, 240, 240))
+        palette.setColor(QPalette.WindowText, Qt.black)
+        palette.setColor(QPalette.Base, Qt.white)
+        palette.setColor(QPalette.AlternateBase, QColor(240, 240, 240))
+        palette.setColor(QPalette.ToolTipBase, Qt.white)
+        palette.setColor(QPalette.ToolTipText, Qt.black)
+        palette.setColor(QPalette.Text, Qt.black)
+        palette.setColor(QPalette.Button, QColor(240, 240, 240))
+        palette.setColor(QPalette.ButtonText, Qt.black)
+        palette.setColor(QPalette.BrightText, Qt.white)
+        palette.setColor(QPalette.Link, QColor(0, 0, 255))
+        palette.setColor(QPalette.Highlight, QColor(76, 163, 224))
+        palette.setColor(QPalette.HighlightedText, Qt.white)
+        app.setPalette(palette)
+        app.styleHints().setColorScheme(Qt.ColorScheme.Light)
+    elif mode == "Dark":
+        # Save original state on first call
+        if _original_style is None:
+            _original_style = app.style().objectName()
+        if _original_palette is None:
+            _original_palette = app.palette()
+
+        app.setStyle("Fusion")
+        palette = QPalette()
+        dark_color = QColor(53, 53, 53)
+        disabled_color = QColor(127, 127, 127)
+        palette.setColor(QPalette.Window, dark_color)
+        palette.setColor(QPalette.WindowText, Qt.white)
+        palette.setColor(QPalette.Base, QColor(25, 25, 25))
+        palette.setColor(QPalette.AlternateBase, dark_color)
+        palette.setColor(QPalette.ToolTipBase, dark_color)
+        palette.setColor(QPalette.ToolTipText, Qt.white)
+        palette.setColor(QPalette.Text, Qt.white)
+        palette.setColor(QPalette.Button, dark_color)
+        palette.setColor(QPalette.ButtonText, Qt.white)
+        palette.setColor(QPalette.BrightText, Qt.white)
+        palette.setColor(QPalette.Link, QColor(42, 130, 218))
+        palette.setColor(QPalette.Highlight, QColor(42, 130, 218))
+        palette.setColor(QPalette.HighlightedText, Qt.black)
+        palette.setColor(QPalette.Disabled, QPalette.Text, disabled_color)
+        palette.setColor(QPalette.Disabled, QPalette.ButtonText, disabled_color)
+        app.setPalette(palette)
+        app.styleHints().setColorScheme(Qt.ColorScheme.Dark)
+
+
+def get_theme() -> str:
+    """Get the saved theme preference.
+
+    Returns
+    -------
+    str
+        One of "System" (default), "Light", or "Dark".
+    """
+    settings = QSettings()
+    value = settings.value("theme", "System")
+    if isinstance(value, str):
+        return value
+    return "System"
+
+
+def set_theme(mode: str) -> None:
+    """Save the theme preference.
+
+    Parameters
+    ----------
+    mode : str
+        One of "System", "Light", or "Dark".
+    """
+    settings = QSettings()
+    settings.setValue("theme", mode)

--- a/src/darsia/gui/ui/theme.py
+++ b/src/darsia/gui/ui/theme.py
@@ -1,8 +1,7 @@
 """Theme switcher for Light/Dark/System modes with persistence."""
 
-from PySide6.QtCore import Qt
+from PySide6.QtCore import QSettings, Qt
 from PySide6.QtGui import QColor, QPalette
-from PySide6.QtCore import QSettings
 
 _original_style = None
 _original_palette = None


### PR DESCRIPTION
Enables switching themes (system, dark, light). On first try, the layout design switches mildly e.g. for settings > corrections. The theme "System" will be used for development. For now.