### PR TITLE
Hide for now attr that cannot be rendered

### DIFF
--- a/src/darsia/presets/workflows/config/analysis.py
+++ b/src/darsia/presets/workflows/config/analysis.py
@@ -337,7 +337,8 @@ class AnalysisThresholdingConfig:
 @dataclass
 class AnalysisSegmentationConfig:
     config: SegmentationConfig | dict[str, SegmentationConfig] = field(
-        default_factory=lambda: SegmentationConfig(), metadata={"name": "Config"}
+        default_factory=lambda: SegmentationConfig(),
+        metadata={"name": "Config", "hidden": True},
     )
     folder: Path = field(
         default_factory=Path,
@@ -402,10 +403,12 @@ class AnalysisMassConfig:
     The value must be a non-empty key defined in the centralized
     ``[color.*.*]`` registry.
     """
-    roi: dict[str, RoiConfig] = field(default_factory=dict, metadata={"name": "ROI"})
+    roi: dict[str, RoiConfig] = field(
+        default_factory=dict, metadata={"name": "ROI", "hidden": True}
+    )
     """ROI configurations for mass analysis."""
     roi_and_label: dict[str, RoiAndLabelConfig] = field(
-        default_factory=dict, metadata={"name": "ROI and label"}
+        default_factory=dict, metadata={"name": "ROI and label", "hidden": True}
     )
     """ROI and label configurations for mass analysis."""
     export: list[str] | None = field(
@@ -422,7 +425,7 @@ class AnalysisMassConfig:
     )
     """Path to the results folder for mass analysis."""
     contour_smoother: darsia.ContourSmoother | None = field(
-        default=None, metadata={"name": "Contour smoother"}
+        default=None, metadata={"name": "Contour smoother", "hidden": True}
     )
     """Optional contour smoother for finger contours."""
 
@@ -544,10 +547,12 @@ class AnalysisMassConfig:
 
 @dataclass
 class AnalysisVolumeConfig:
-    roi: dict[str, RoiConfig] = field(default_factory=dict, metadata={"name": "ROI"})
+    roi: dict[str, RoiConfig] = field(
+        default_factory=dict, metadata={"name": "ROI", "hidden": True}
+    )
     """ROI configurations for volume analysis."""
     roi_and_label: dict[str, RoiAndLabelConfig] = field(
-        default_factory=dict, metadata={"name": "ROI and label"}
+        default_factory=dict, metadata={"name": "ROI and label", "hidden": True}
     )
     """ROI and label configurations for volume analysis."""
     folder: Path = field(
@@ -621,6 +626,7 @@ class AnalysisExpertKnowledgeConfig:
         metadata={
             "name": "Saturation ROIs",
             "help": "ROI keys where saturation_g constraints apply.",
+            "hidden": True,
         },
     )
     """ROI registry keys constraining where saturation_g may be non-zero."""
@@ -629,6 +635,7 @@ class AnalysisExpertKnowledgeConfig:
         metadata={
             "name": "Concentration ROIs",
             "help": "ROI keys where concentration_aq constraints apply.",
+            "hidden": True,
         },
     )
     """ROI registry keys constraining where concentration_aq may be non-zero."""
@@ -676,7 +683,8 @@ class AnalysisExpertKnowledgeConfig:
 @dataclass
 class AnalysisFingersConfig:
     config: FingersConfig | dict[str, FingersConfig] = field(
-        default_factory=lambda: FingersConfig(), metadata={"name": "Config"}
+        default_factory=lambda: FingersConfig(),
+        metadata={"name": "Config", "hidden": True},
     )
     folder: Path = field(
         default_factory=Path,

--- a/src/darsia/presets/workflows/config/helper.py
+++ b/src/darsia/presets/workflows/config/helper.py
@@ -124,7 +124,9 @@ class HelperResultsConfig:
         },
     )
     cmap: str | None = None
-    roi: list[str] | None = None
+    roi: list[str] | None = field(
+        default=None, metadata={"name": "ROI", "hidden": True}
+    )
 
     def load(
         self,

--- a/src/darsia/presets/workflows/config/restoration.py
+++ b/src/darsia/presets/workflows/config/restoration.py
@@ -71,7 +71,9 @@ class TVDConfig:
 @dataclass
 class RestorationConfig:
     method: Literal["volume_average", "tvd"] | None = "volume_average"
-    options: VolumeAveragingConfig | TVDConfig | None = None
+    options: VolumeAveragingConfig | TVDConfig | None = field(
+        default=None, metadata={"name": "Options", "hidden": True}
+    )
     ignore: list[str] = field(default_factory=list)
 
     def load(self, path: Path | dict) -> "RestorationConfig":

--- a/src/darsia/presets/workflows/config/roi.py
+++ b/src/darsia/presets/workflows/config/roi.py
@@ -33,6 +33,7 @@ class RoiConfig:
         return self
 
 
+@dataclass
 class MultiRoiConfig:
     """Configuration for multiple ROIs."""
 

--- a/src/darsia/presets/workflows/config/roi_registry.py
+++ b/src/darsia/presets/workflows/config/roi_registry.py
@@ -1,6 +1,7 @@
 """Registry for ROI configurations loaded from a top-level [roi.*] TOML section."""
 
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 
 from .roi import RoiAndLabelConfig, RoiAndSubroiConfig, RoiConfig
@@ -9,6 +10,7 @@ from .utils import _get_section_from_toml
 logger = logging.getLogger(__name__)
 
 
+@dataclass
 class RoiRegistry:
     """A registry of named ROI entries loaded from a top-level [roi.*] TOML section.
 


### PR DESCRIPTION
To circumvent errors in the development, hide attributes in configs that so far do not have support for the GUI (several custom dicts, registries etc.