### PR TITLE
Color tab in Qt gui

### DIFF
--- a/src/darsia/gui/ui/schema/dataclass_introspection.py
+++ b/src/darsia/gui/ui/schema/dataclass_introspection.py
@@ -7,6 +7,9 @@ from typing import Any, Union, get_args, get_origin, get_type_hints
 
 from darsia.presets.workflows.config.analysis import AnalysisConfig
 from darsia.presets.workflows.config.calibration import CalibrationConfig
+from darsia.presets.workflows.config.color_embedding_registry import (
+    ColorEmbeddingRegistryConfig,
+)
 from darsia.presets.workflows.config.corrections import CorrectionsConfig
 from darsia.presets.workflows.config.data import DataConfig
 from darsia.presets.workflows.config.data_registry import DataRegistry
@@ -28,6 +31,7 @@ from darsia.presets.workflows.config.workflow_utils import WorkflowUtilsConfig
 SECTION_TO_DATACLASS = {
     "analysis": AnalysisConfig,
     "calibration": CalibrationConfig,
+    "color": ColorEmbeddingRegistryConfig,
     "corrections": CorrectionsConfig,
     "data": DataConfig,
     "depth": DepthConfig,
@@ -53,6 +57,7 @@ ALL_SECTIONS = [
     "registry",
     "format_registry",
     "roi",
+    "color",
     "rig",
     "corrections",
     "restoration",

--- a/src/darsia/gui/ui/settings.py
+++ b/src/darsia/gui/ui/settings.py
@@ -1687,9 +1687,10 @@ class SettingsFactory:
                 calibration_folder_edit = QLineEdit()
                 calibration_folder_edit.setPlaceholderText("calib_folder")
                 calibration_folder_edit.setMaximumWidth(100)
-                if "calibration_folder" in entry_data and entry_data[
-                    "calibration_folder"
-                ]:
+                if (
+                    "calibration_folder" in entry_data
+                    and entry_data["calibration_folder"]
+                ):
                     calibration_folder_edit.setText(
                         str(entry_data["calibration_folder"])
                     )
@@ -1878,9 +1879,10 @@ class SettingsFactory:
                 calibration_folder_edit = QLineEdit()
                 calibration_folder_edit.setPlaceholderText("calib_folder")
                 calibration_folder_edit.setMaximumWidth(100)
-                if "calibration_folder" in entry_data and entry_data[
-                    "calibration_folder"
-                ]:
+                if (
+                    "calibration_folder" in entry_data
+                    and entry_data["calibration_folder"]
+                ):
                     calibration_folder_edit.setText(
                         str(entry_data["calibration_folder"])
                     )
@@ -2038,9 +2040,10 @@ class SettingsFactory:
                 calibration_folder_edit = QLineEdit()
                 calibration_folder_edit.setPlaceholderText("calib_folder")
                 calibration_folder_edit.setMaximumWidth(100)
-                if "calibration_folder" in entry_data and entry_data[
-                    "calibration_folder"
-                ]:
+                if (
+                    "calibration_folder" in entry_data
+                    and entry_data["calibration_folder"]
+                ):
                     calibration_folder_edit.setText(
                         str(entry_data["calibration_folder"])
                     )
@@ -3408,7 +3411,8 @@ class SettingsFactory:
                 continue
             # Skip path_map, int_group_list, int_list_map, time_interval_map, time_window_map,
             # time_data_map, path_data_map, registry_key_list, format_map, roi_map,
-            # roi_key_list, color_path_map, color_range_map, color_channel_map dicts (handled below)
+            # roi_key_list, color_path_map, color_range_map, color_channel_map dicts
+            # (handled below)
             if isinstance(value, dict) and (
                 "path_map" in value
                 or "int_group_list" in value
@@ -3828,7 +3832,8 @@ class SettingsFactory:
                     # Check for duplicate names across all groups
                     if name_text in color_seen_names:
                         self.main_window.print_log(
-                            f"Warning: duplicate color embedding name '{name_text}' skipped during save"
+                            f"Warning: duplicate color embedding name '{name_text}' skipped "
+                            "during save"
                         )
                         continue
                     color_seen_names.add(name_text)
@@ -3839,7 +3844,9 @@ class SettingsFactory:
                     entry["name"] = name_text
                     entry["mode"] = mode_combo.currentText().strip()
                     entry["basis"] = basis_combo.currentText().strip()
-                    entry["calibration_mode"] = calibration_mode_combo.currentText().strip()
+                    entry["calibration_mode"] = (
+                        calibration_mode_combo.currentText().strip()
+                    )
 
                     # baseline/data dropdowns
                     baseline_text = baseline_combo.currentText().strip()
@@ -3852,17 +3859,23 @@ class SettingsFactory:
                     # rois: parse comma-separated list
                     rois_text = rois_edit.text().strip()
                     if rois_text:
-                        entry["rois"] = [r.strip() for r in rois_text.split(",") if r.strip()]
+                        entry["rois"] = [
+                            r.strip() for r in rois_text.split(",") if r.strip()
+                        ]
                     else:
                         entry["rois"] = []
 
                     # numeric fields
                     try:
-                        entry["num_segments"] = int(num_segments_edit.text().strip() or "1")
+                        entry["num_segments"] = int(
+                            num_segments_edit.text().strip() or "1"
+                        )
                     except ValueError:
                         pass
                     try:
-                        entry["resolution"] = int(resolution_edit.text().strip() or "51")
+                        entry["resolution"] = int(
+                            resolution_edit.text().strip() or "51"
+                        )
                     except ValueError:
                         pass
                     try:
@@ -3897,7 +3910,9 @@ class SettingsFactory:
                     entry["ignore_baseline_spectrum"] = (
                         ignore_baseline_combo.currentText().strip()
                     )
-                    entry["histogram_weighting"] = histogram_weighting_combo.currentText().strip()
+                    entry["histogram_weighting"] = (
+                        histogram_weighting_combo.currentText().strip()
+                    )
 
                     # calibration_folder (optional)
                     calibration_folder_text = calibration_folder_edit.text().strip()
@@ -3924,7 +3939,8 @@ class SettingsFactory:
 
                     if name_text in color_seen_names:
                         self.main_window.print_log(
-                            f"Warning: duplicate color embedding name '{name_text}' skipped during save"
+                            f"Warning: duplicate color embedding name '{name_text}' skipped "
+                            "during save"
                         )
                         continue
                     color_seen_names.add(name_text)
@@ -3984,7 +4000,8 @@ class SettingsFactory:
 
                     if name_text in color_seen_names:
                         self.main_window.print_log(
-                            f"Warning: duplicate color embedding name '{name_text}' skipped during save"
+                            f"Warning: duplicate color embedding name '{name_text}' skipped "
+                            "during save"
                         )
                         continue
                     color_seen_names.add(name_text)

--- a/src/darsia/gui/ui/settings.py
+++ b/src/darsia/gui/ui/settings.py
@@ -55,6 +55,10 @@ class SettingsFactory:
         "registry_key_list",
         "roi_map",
         "roi_key_list",
+        "color_key_list",
+        "color_path_map",
+        "color_range_map",
+        "color_channel_map",
     }
 
     def __init__(self, main_window):
@@ -325,6 +329,21 @@ class SettingsFactory:
                         "roi_map": True,
                         "rows": field_or_result["rows"],
                     }
+                elif "color_path_map" in field_or_result:
+                    self.main_window.settings_inputs[setting["key"]] = {
+                        "color_path_map": True,
+                        "rows": field_or_result["rows"],
+                    }
+                elif "color_range_map" in field_or_result:
+                    self.main_window.settings_inputs[setting["key"]] = {
+                        "color_range_map": True,
+                        "rows": field_or_result["rows"],
+                    }
+                elif "color_channel_map" in field_or_result:
+                    self.main_window.settings_inputs[setting["key"]] = {
+                        "color_channel_map": True,
+                        "rows": field_or_result["rows"],
+                    }
                 elif "roi_key_list" in field_or_result:
                     result_dict = {
                         "roi_key_list": True,
@@ -473,6 +492,22 @@ class SettingsFactory:
             return self.create_roi_map_input(setting_dict, form_context=form_context)
         elif setting_type == "roi_key_list":
             return self.create_roi_key_list_input(
+                setting_dict, form_context=form_context
+            )
+        elif setting_type == "color_key_list":
+            return self.create_color_key_list_input(
+                setting_dict, form_context=form_context
+            )
+        elif setting_type == "color_path_map":
+            return self.create_color_path_map_input(
+                setting_dict, form_context=form_context
+            )
+        elif setting_type == "color_range_map":
+            return self.create_color_range_map_input(
+                setting_dict, form_context=form_context
+            )
+        elif setting_type == "color_channel_map":
+            return self.create_color_channel_map_input(
                 setting_dict, form_context=form_context
             )
         else:
@@ -1427,6 +1462,650 @@ class SettingsFactory:
         else:
             return display_name, {"roi_map": True, "rows": []}
 
+    def create_color_path_map_input(self, setting_dict, form_context=None):
+        """Create a dict[str, ColorPathEmbedding] editor for type='path' rows.
+
+        Each row has 16 widgets: name, mode, basis, calibration_mode, baseline,
+        data, rois, num_segments, resolution, threshold_baseline,
+        threshold_calibration, reference_label, ignore_labels,
+        ignore_baseline_spectrum, histogram_weighting, calibration_folder, plus
+        remove button.
+
+        Returns (display_name, enriched_dict) with "widget", "color_path_map",
+        and "rows" (list of 16-tuples with passthrough dict).
+        """
+        key = setting_dict["key"]
+        display_name = setting_dict.get("name", key)
+
+        # Read color entries from config_dict, filter to type='path'
+        color_list = self.main_window.config_dict.get("color", [])
+        value = {
+            entry.get("name", ""): entry
+            for entry in color_list
+            if entry.get("name") and entry.get("type") == "path"
+        }
+
+        # Gather DataRegistry keys for baseline/data dropdowns
+        registry = self.main_window.config_dict.get("registry", {})
+        data_keys = sorted(
+            set(registry.get("interval_registry", {}))
+            | set(registry.get("time_registry", {}))
+            | set(registry.get("path_registry", {}))
+        )
+
+        row_data_list = []
+        row_edits = []
+
+        def refresh_remove_buttons():
+            show_remove = len(row_data_list) > 1
+            for row_data in row_data_list:
+                row_data["remove_button"].setVisible(show_remove)
+
+        add_button = QPushButton("Add color path")
+
+        if form_context:
+            form = form_context["form"]
+
+            # Build header widget
+            header_widget = QWidget()
+            header_layout = QHBoxLayout(header_widget)
+            header_layout.setContentsMargins(0, 0, 0, 0)
+            header_layout.setSpacing(4)
+            header_layout.addWidget(add_button, stretch=1)
+            header_layout.addWidget(build_help_column(setting_dict))
+            form.addRow("", header_widget)
+
+            def add_row(entry_name="", entry_data=None):
+                """Add one color path entry row with 16 widgets."""
+                if entry_data is None:
+                    entry_data = {}
+
+                row_widget = QWidget()
+                row_layout = QHBoxLayout(row_widget)
+                row_layout.setContentsMargins(4, 4, 4, 4)
+                row_layout.setSpacing(4)
+                row_widget.setMinimumHeight(28)
+
+                # 1. name
+                name_edit = QLineEdit()
+                name_edit.setPlaceholderText("Name")
+                name_edit.setMaximumWidth(80)
+                if entry_name:
+                    name_edit.setText(str(entry_name))
+                row_layout.addWidget(name_edit, 0)
+
+                # 2. mode
+                mode_combo = QComboBox()
+                mode_combo.addItems(["relative", "absolute"])
+                mode_combo.setMaximumWidth(80)
+                if "mode" in entry_data:
+                    mode_combo.setCurrentText(str(entry_data["mode"]))
+                else:
+                    mode_combo.setCurrentText("relative")
+                row_layout.addWidget(mode_combo, 0)
+
+                # 3. basis
+                basis_combo = QComboBox()
+                basis_combo.addItems(["labels", "facies", "global"])
+                basis_combo.setMaximumWidth(80)
+                if "basis" in entry_data:
+                    basis_combo.setCurrentText(str(entry_data["basis"]))
+                else:
+                    basis_combo.setCurrentText("labels")
+                row_layout.addWidget(basis_combo, 0)
+
+                # 4. calibration_mode
+                calibration_mode_combo = QComboBox()
+                calibration_mode_combo.addItems(["auto", "manual"])
+                calibration_mode_combo.setMaximumWidth(80)
+                if "calibration_mode" in entry_data:
+                    calibration_mode_combo.setCurrentText(
+                        str(entry_data["calibration_mode"])
+                    )
+                else:
+                    calibration_mode_combo.setCurrentText("auto")
+                row_layout.addWidget(calibration_mode_combo, 0)
+
+                # 5. baseline (combo, DataRegistry keys)
+                baseline_combo = QComboBox()
+                baseline_combo.addItems(data_keys)
+                baseline_combo.setMaximumWidth(100)
+                if "baseline" in entry_data and entry_data["baseline"]:
+                    baseline_combo.setCurrentText(str(entry_data["baseline"]))
+                row_layout.addWidget(baseline_combo, 0)
+
+                # 6. data (combo, DataRegistry keys)
+                data_combo = QComboBox()
+                data_combo.addItems(data_keys)
+                data_combo.setMaximumWidth(100)
+                if "data" in entry_data and entry_data["data"]:
+                    if isinstance(entry_data["data"], (list, tuple)):
+                        data_combo.setCurrentText(str(entry_data["data"][0]))
+                    else:
+                        data_combo.setCurrentText(str(entry_data["data"]))
+                row_layout.addWidget(data_combo, 0)
+
+                # 7. rois (comma-separated list)
+                rois_edit = QLineEdit()
+                rois_edit.setPlaceholderText("roi1,roi2")
+                rois_edit.setMaximumWidth(100)
+                if "rois" in entry_data and entry_data["rois"]:
+                    rois_edit.setText(",".join(entry_data["rois"]))
+                row_layout.addWidget(rois_edit, 0)
+
+                # 8. num_segments
+                num_segments_edit = QLineEdit()
+                num_segments_edit.setPlaceholderText("segments")
+                num_segments_edit.setMaximumWidth(80)
+                if "num_segments" in entry_data:
+                    num_segments_edit.setText(str(entry_data["num_segments"]))
+                else:
+                    num_segments_edit.setText("1")
+                row_layout.addWidget(num_segments_edit, 0)
+
+                # 9. resolution
+                resolution_edit = QLineEdit()
+                resolution_edit.setPlaceholderText("resolution")
+                resolution_edit.setMaximumWidth(80)
+                if "resolution" in entry_data:
+                    resolution_edit.setText(str(entry_data["resolution"]))
+                else:
+                    resolution_edit.setText("51")
+                row_layout.addWidget(resolution_edit, 0)
+
+                # 10. threshold_baseline
+                threshold_baseline_edit = QLineEdit()
+                threshold_baseline_edit.setPlaceholderText("thr_baseline")
+                threshold_baseline_edit.setMaximumWidth(90)
+                if "threshold_baseline" in entry_data:
+                    threshold_baseline_edit.setText(
+                        str(entry_data["threshold_baseline"])
+                    )
+                else:
+                    threshold_baseline_edit.setText("0.0")
+                row_layout.addWidget(threshold_baseline_edit, 0)
+
+                # 11. threshold_calibration
+                threshold_calibration_edit = QLineEdit()
+                threshold_calibration_edit.setPlaceholderText("thr_calib")
+                threshold_calibration_edit.setMaximumWidth(90)
+                if "threshold_calibration" in entry_data:
+                    threshold_calibration_edit.setText(
+                        str(entry_data["threshold_calibration"])
+                    )
+                else:
+                    threshold_calibration_edit.setText("0.0")
+                row_layout.addWidget(threshold_calibration_edit, 0)
+
+                # 12. reference_label
+                reference_label_edit = QLineEdit()
+                reference_label_edit.setPlaceholderText("ref_label")
+                reference_label_edit.setMaximumWidth(80)
+                if "reference_label" in entry_data:
+                    reference_label_edit.setText(str(entry_data["reference_label"]))
+                else:
+                    reference_label_edit.setText("0")
+                row_layout.addWidget(reference_label_edit, 0)
+
+                # 13. ignore_labels (comma-separated ints)
+                ignore_labels_edit = QLineEdit()
+                ignore_labels_edit.setPlaceholderText("labels")
+                ignore_labels_edit.setMaximumWidth(80)
+                if "ignore_labels" in entry_data and entry_data["ignore_labels"]:
+                    ignore_labels_edit.setText(
+                        ",".join(str(x) for x in entry_data["ignore_labels"])
+                    )
+                row_layout.addWidget(ignore_labels_edit, 0)
+
+                # 14. ignore_baseline_spectrum
+                ignore_baseline_combo = QComboBox()
+                ignore_baseline_combo.addItems(["none", "baseline", "expanded"])
+                ignore_baseline_combo.setMaximumWidth(90)
+                if "ignore_baseline_spectrum" in entry_data:
+                    ignore_baseline_combo.setCurrentText(
+                        str(entry_data["ignore_baseline_spectrum"])
+                    )
+                else:
+                    ignore_baseline_combo.setCurrentText("expanded")
+                row_layout.addWidget(ignore_baseline_combo, 0)
+
+                # 15. histogram_weighting
+                histogram_weighting_combo = QComboBox()
+                histogram_weighting_combo.addItems(
+                    ["threshold", "wls", "wls_sqrt", "wls_log"]
+                )
+                histogram_weighting_combo.setMaximumWidth(100)
+                if "histogram_weighting" in entry_data:
+                    histogram_weighting_combo.setCurrentText(
+                        str(entry_data["histogram_weighting"])
+                    )
+                else:
+                    histogram_weighting_combo.setCurrentText("threshold")
+                row_layout.addWidget(histogram_weighting_combo, 0)
+
+                # 16. calibration_folder (optional)
+                calibration_folder_edit = QLineEdit()
+                calibration_folder_edit.setPlaceholderText("calib_folder")
+                calibration_folder_edit.setMaximumWidth(100)
+                if "calibration_folder" in entry_data and entry_data[
+                    "calibration_folder"
+                ]:
+                    calibration_folder_edit.setText(
+                        str(entry_data["calibration_folder"])
+                    )
+                row_layout.addWidget(calibration_folder_edit, 0)
+
+                # Remove button
+                remove_button = QPushButton("Remove")
+                remove_button.setMaximumWidth(80)
+
+                def remove():
+                    row_idx, _ = form.getWidgetPosition(row_widget)
+                    form.removeRow(row_idx)
+                    if row_data in row_data_list:
+                        row_data_list.remove(row_data)
+                    if edits in row_edits:
+                        row_edits.remove(edits)
+                    refresh_remove_buttons()
+
+                remove_button.clicked.connect(remove)
+                row_layout.addWidget(remove_button, 0)
+
+                # Insert row into form
+                header_idx, _ = form.getWidgetPosition(header_widget)
+                if row_data_list:
+                    last_idx, _ = form.getWidgetPosition(row_data_list[-1]["widget"])
+                    insert_idx = last_idx + 1
+                else:
+                    insert_idx = header_idx + 1
+
+                form.insertRow(insert_idx, "", row_widget)
+
+                # Store row data and edits (16-tuple)
+                row_data = {"widget": row_widget, "remove_button": remove_button}
+                edits = (
+                    name_edit,
+                    mode_combo,
+                    basis_combo,
+                    calibration_mode_combo,
+                    baseline_combo,
+                    data_combo,
+                    rois_edit,
+                    num_segments_edit,
+                    resolution_edit,
+                    threshold_baseline_edit,
+                    threshold_calibration_edit,
+                    reference_label_edit,
+                    ignore_labels_edit,
+                    ignore_baseline_combo,
+                    histogram_weighting_combo,
+                    calibration_folder_edit,
+                )
+                row_data_list.append(row_data)
+                row_edits.append((edits, entry_data))  # Store passthrough dict too
+                refresh_remove_buttons()
+
+            # Connect add button
+            add_button.clicked.connect(lambda: add_row())
+
+            # Prefill existing entries
+            if value:
+                for entry_name, entry_data in value.items():
+                    add_row(
+                        entry_name, entry_data if isinstance(entry_data, dict) else {}
+                    )
+            else:
+                # At least one empty row
+                add_row()
+
+            # Return enriched dict
+            return display_name, {
+                "widget": header_widget,
+                "color_path_map": True,
+                "rows": row_edits,
+            }
+
+        else:
+            return display_name, {"color_path_map": True, "rows": []}
+
+    def create_color_range_map_input(self, setting_dict, form_context=None):
+        """Create a dict[str, ColorRangeEmbedding] editor for type='range' rows.
+
+        Each row has 6 widgets: name, mode, basis, color_space, range
+        (comma-separated 6 floats), calibration_folder, plus remove button.
+
+        Returns (display_name, enriched_dict) with "widget", "color_range_map",
+        and "rows" (list of 6-tuples with passthrough dict).
+        """
+        key = setting_dict["key"]
+        display_name = setting_dict.get("name", key)
+
+        # Read color entries from config_dict, filter to type='range'
+        color_list = self.main_window.config_dict.get("color", [])
+        value = {
+            entry.get("name", ""): entry
+            for entry in color_list
+            if entry.get("name") and entry.get("type") == "range"
+        }
+
+        row_data_list = []
+        row_edits = []
+
+        def refresh_remove_buttons():
+            show_remove = len(row_data_list) > 1
+            for row_data in row_data_list:
+                row_data["remove_button"].setVisible(show_remove)
+
+        add_button = QPushButton("Add color range")
+
+        if form_context:
+            form = form_context["form"]
+
+            # Build header widget
+            header_widget = QWidget()
+            header_layout = QHBoxLayout(header_widget)
+            header_layout.setContentsMargins(0, 0, 0, 0)
+            header_layout.setSpacing(4)
+            header_layout.addWidget(add_button, stretch=1)
+            header_layout.addWidget(build_help_column(setting_dict))
+            form.addRow("", header_widget)
+
+            def add_row(entry_name="", entry_data=None):
+                """Add one color range entry row with 6 widgets."""
+                if entry_data is None:
+                    entry_data = {}
+
+                row_widget = QWidget()
+                row_layout = QHBoxLayout(row_widget)
+                row_layout.setContentsMargins(4, 4, 4, 4)
+                row_layout.setSpacing(4)
+                row_widget.setMinimumHeight(28)
+
+                # 1. name
+                name_edit = QLineEdit()
+                name_edit.setPlaceholderText("Name")
+                name_edit.setMaximumWidth(80)
+                if entry_name:
+                    name_edit.setText(str(entry_name))
+                row_layout.addWidget(name_edit, 0)
+
+                # 2. mode
+                mode_combo = QComboBox()
+                mode_combo.addItems(["relative", "absolute"])
+                mode_combo.setMaximumWidth(80)
+                if "mode" in entry_data:
+                    mode_combo.setCurrentText(str(entry_data["mode"]))
+                else:
+                    mode_combo.setCurrentText("absolute")
+                row_layout.addWidget(mode_combo, 0)
+
+                # 3. basis
+                basis_combo = QComboBox()
+                basis_combo.addItems(["labels", "facies", "global"])
+                basis_combo.setMaximumWidth(80)
+                if "basis" in entry_data:
+                    basis_combo.setCurrentText(str(entry_data["basis"]))
+                else:
+                    basis_combo.setCurrentText("global")
+                row_layout.addWidget(basis_combo, 0)
+
+                # 4. color_space
+                color_space_edit = QLineEdit()
+                color_space_edit.setPlaceholderText("RGB/HSV")
+                color_space_edit.setMaximumWidth(80)
+                if "color_space" in entry_data:
+                    color_space_edit.setText(str(entry_data["color_space"]))
+                row_layout.addWidget(color_space_edit, 0)
+
+                # 5. range (3 [min,max] pairs as 6 comma-separated floats)
+                range_edit = QLineEdit()
+                range_edit.setPlaceholderText("min1,max1,min2,max2,min3,max3")
+                range_edit.setMaximumWidth(180)
+                if "range" in entry_data and entry_data["range"]:
+                    # Flatten the 3 pairs into 6 values
+                    range_vals = []
+                    for pair in entry_data["range"]:
+                        if isinstance(pair, (list, tuple)) and len(pair) == 2:
+                            min_v = "none" if pair[0] is None else str(pair[0])
+                            max_v = "none" if pair[1] is None else str(pair[1])
+                            range_vals.append(min_v)
+                            range_vals.append(max_v)
+                    if range_vals:
+                        range_edit.setText(",".join(range_vals))
+                row_layout.addWidget(range_edit, 0)
+
+                # 6. calibration_folder (optional)
+                calibration_folder_edit = QLineEdit()
+                calibration_folder_edit.setPlaceholderText("calib_folder")
+                calibration_folder_edit.setMaximumWidth(100)
+                if "calibration_folder" in entry_data and entry_data[
+                    "calibration_folder"
+                ]:
+                    calibration_folder_edit.setText(
+                        str(entry_data["calibration_folder"])
+                    )
+                row_layout.addWidget(calibration_folder_edit, 0)
+
+                # Remove button
+                remove_button = QPushButton("Remove")
+                remove_button.setMaximumWidth(80)
+
+                def remove():
+                    row_idx, _ = form.getWidgetPosition(row_widget)
+                    form.removeRow(row_idx)
+                    if row_data in row_data_list:
+                        row_data_list.remove(row_data)
+                    if edits in row_edits:
+                        row_edits.remove(edits)
+                    refresh_remove_buttons()
+
+                remove_button.clicked.connect(remove)
+                row_layout.addWidget(remove_button, 0)
+
+                # Insert row into form
+                header_idx, _ = form.getWidgetPosition(header_widget)
+                if row_data_list:
+                    last_idx, _ = form.getWidgetPosition(row_data_list[-1]["widget"])
+                    insert_idx = last_idx + 1
+                else:
+                    insert_idx = header_idx + 1
+
+                form.insertRow(insert_idx, "", row_widget)
+
+                # Store row data and edits (6-tuple)
+                row_data = {"widget": row_widget, "remove_button": remove_button}
+                edits = (
+                    name_edit,
+                    mode_combo,
+                    basis_combo,
+                    color_space_edit,
+                    range_edit,
+                    calibration_folder_edit,
+                )
+                row_data_list.append(row_data)
+                row_edits.append((edits, entry_data))  # Store passthrough dict
+                refresh_remove_buttons()
+
+            # Connect add button
+            add_button.clicked.connect(lambda: add_row())
+
+            # Prefill existing entries
+            if value:
+                for entry_name, entry_data in value.items():
+                    add_row(
+                        entry_name, entry_data if isinstance(entry_data, dict) else {}
+                    )
+            else:
+                add_row()
+
+            return display_name, {
+                "widget": header_widget,
+                "color_range_map": True,
+                "rows": row_edits,
+            }
+
+        else:
+            return display_name, {"color_range_map": True, "rows": []}
+
+    def create_color_channel_map_input(self, setting_dict, form_context=None):
+        """Create a dict[str, ColorChannelEmbedding] editor for type='channel' rows.
+
+        Each row has 5 widgets: name, mode, color_space, channel, calibration_folder,
+        plus remove button.
+
+        Returns (display_name, enriched_dict) with "widget", "color_channel_map",
+        and "rows" (list of 5-tuples with passthrough dict).
+        """
+        key = setting_dict["key"]
+        display_name = setting_dict.get("name", key)
+
+        # Read color entries from config_dict, filter to type='channel'
+        color_list = self.main_window.config_dict.get("color", [])
+        value = {
+            entry.get("name", ""): entry
+            for entry in color_list
+            if entry.get("name") and entry.get("type") == "channel"
+        }
+
+        row_data_list = []
+        row_edits = []
+
+        def refresh_remove_buttons():
+            show_remove = len(row_data_list) > 1
+            for row_data in row_data_list:
+                row_data["remove_button"].setVisible(show_remove)
+
+        add_button = QPushButton("Add color channel")
+
+        if form_context:
+            form = form_context["form"]
+
+            # Build header widget
+            header_widget = QWidget()
+            header_layout = QHBoxLayout(header_widget)
+            header_layout.setContentsMargins(0, 0, 0, 0)
+            header_layout.setSpacing(4)
+            header_layout.addWidget(add_button, stretch=1)
+            header_layout.addWidget(build_help_column(setting_dict))
+            form.addRow("", header_widget)
+
+            def add_row(entry_name="", entry_data=None):
+                """Add one color channel entry row with 5 widgets."""
+                if entry_data is None:
+                    entry_data = {}
+
+                row_widget = QWidget()
+                row_layout = QHBoxLayout(row_widget)
+                row_layout.setContentsMargins(4, 4, 4, 4)
+                row_layout.setSpacing(4)
+                row_widget.setMinimumHeight(28)
+
+                # 1. name
+                name_edit = QLineEdit()
+                name_edit.setPlaceholderText("Name")
+                name_edit.setMaximumWidth(80)
+                if entry_name:
+                    name_edit.setText(str(entry_name))
+                row_layout.addWidget(name_edit, 0)
+
+                # 2. mode
+                mode_combo = QComboBox()
+                mode_combo.addItems(["relative", "absolute"])
+                mode_combo.setMaximumWidth(80)
+                if "mode" in entry_data:
+                    mode_combo.setCurrentText(str(entry_data["mode"]))
+                else:
+                    mode_combo.setCurrentText("absolute")
+                row_layout.addWidget(mode_combo, 0)
+
+                # 3. color_space
+                color_space_edit = QLineEdit()
+                color_space_edit.setPlaceholderText("RGB/HSV")
+                color_space_edit.setMaximumWidth(80)
+                if "color_space" in entry_data:
+                    color_space_edit.setText(str(entry_data["color_space"]))
+                row_layout.addWidget(color_space_edit, 0)
+
+                # 4. channel
+                channel_edit = QLineEdit()
+                channel_edit.setPlaceholderText("r/g/b")
+                channel_edit.setMaximumWidth(80)
+                if "channel" in entry_data:
+                    channel_edit.setText(str(entry_data["channel"]))
+                row_layout.addWidget(channel_edit, 0)
+
+                # 5. calibration_folder (optional)
+                calibration_folder_edit = QLineEdit()
+                calibration_folder_edit.setPlaceholderText("calib_folder")
+                calibration_folder_edit.setMaximumWidth(100)
+                if "calibration_folder" in entry_data and entry_data[
+                    "calibration_folder"
+                ]:
+                    calibration_folder_edit.setText(
+                        str(entry_data["calibration_folder"])
+                    )
+                row_layout.addWidget(calibration_folder_edit, 0)
+
+                # Remove button
+                remove_button = QPushButton("Remove")
+                remove_button.setMaximumWidth(80)
+
+                def remove():
+                    row_idx, _ = form.getWidgetPosition(row_widget)
+                    form.removeRow(row_idx)
+                    if row_data in row_data_list:
+                        row_data_list.remove(row_data)
+                    if edits in row_edits:
+                        row_edits.remove(edits)
+                    refresh_remove_buttons()
+
+                remove_button.clicked.connect(remove)
+                row_layout.addWidget(remove_button, 0)
+
+                # Insert row into form
+                header_idx, _ = form.getWidgetPosition(header_widget)
+                if row_data_list:
+                    last_idx, _ = form.getWidgetPosition(row_data_list[-1]["widget"])
+                    insert_idx = last_idx + 1
+                else:
+                    insert_idx = header_idx + 1
+
+                form.insertRow(insert_idx, "", row_widget)
+
+                # Store row data and edits (5-tuple)
+                row_data = {"widget": row_widget, "remove_button": remove_button}
+                edits = (
+                    name_edit,
+                    mode_combo,
+                    color_space_edit,
+                    channel_edit,
+                    calibration_folder_edit,
+                )
+                row_data_list.append(row_data)
+                row_edits.append((edits, entry_data))  # Store passthrough dict
+                refresh_remove_buttons()
+
+            # Connect add button
+            add_button.clicked.connect(lambda: add_row())
+
+            # Prefill existing entries
+            if value:
+                for entry_name, entry_data in value.items():
+                    add_row(
+                        entry_name, entry_data if isinstance(entry_data, dict) else {}
+                    )
+            else:
+                add_row()
+
+            return display_name, {
+                "widget": header_widget,
+                "color_channel_map": True,
+                "rows": row_edits,
+            }
+
+        else:
+            return display_name, {"color_channel_map": True, "rows": []}
+
     def create_registry_key_list_input(self, setting_dict, form_context=None):
         """Create a multi-row registry-key selector with dropdowns.
 
@@ -1855,6 +2534,146 @@ class SettingsFactory:
 
         else:
             return display_name, {"roi_key_list": True, "rows": []}
+
+    def create_color_key_list_input(self, setting_dict, form_context=None):
+        """Create a multi-row color-embedding-key selector with dropdowns.
+
+        Reads from the [[color]] array-of-tables TOML shape.
+        Each row is a QComboBox populated with available color embedding names.
+
+        Returns (display_name, enriched_dict) with "widget" and "rows".
+        """
+        key = setting_dict["key"]
+        display_name = setting_dict.get("name", key)
+
+        # Gather available color-embedding keys from the raw [[color]] array-of-tables
+        color_list = self.main_window.config_dict.get("color", [])
+        available_keys = sorted(
+            {entry.get("name", "") for entry in color_list if entry.get("name")}
+        )
+
+        # Get current value and normalize to list
+        value = self.get_value(self.main_window.config_dict, key)
+        if value is None:
+            current_keys = []
+        elif isinstance(value, str):
+            current_keys = [value]
+        elif isinstance(value, list):
+            current_keys = value
+        else:
+            current_keys = []
+
+        # For single-value fields (max_rows=1), cap the selection
+        max_rows = setting_dict.get("max_rows")
+        if max_rows == 1:
+            current_keys = current_keys[:1]
+
+        row_data_list = []
+        row_combos = []
+
+        def refresh_remove_buttons():
+            show_remove = len(row_data_list) > 1
+            for row_data in row_data_list:
+                row_data["remove_button"].setVisible(show_remove)
+
+        add_button = QPushButton("Add Color")
+
+        if form_context:
+            form = form_context["form"]
+
+            # Build header widget
+            header_widget = QWidget()
+            header_layout = QHBoxLayout(header_widget)
+            header_layout.setContentsMargins(0, 0, 0, 0)
+            header_layout.setSpacing(4)
+
+            if max_rows != 1:
+                header_layout.addWidget(add_button, stretch=1)
+            header_layout.addWidget(build_help_column(setting_dict))
+            form.addRow("", header_widget)
+
+            def add_row(selected_key=""):
+                """Add a row with a color-embedding-key dropdown."""
+                row_widget = QWidget()
+                row_layout = QHBoxLayout(row_widget)
+                row_layout.setContentsMargins(4, 4, 4, 4)
+                row_layout.setSpacing(4)
+                row_widget.setMinimumHeight(28)
+
+                # Dropdown with available keys + stale/appended values
+                combo = QComboBox()
+                combo.setEditable(False)
+                all_options = list(available_keys)
+
+                # Add selected_key if not already in options (stale/filtered-out value)
+                if selected_key and selected_key not in all_options:
+                    all_options.append(selected_key)
+                    all_options.sort()
+
+                combo.addItems(all_options)
+                if selected_key:
+                    combo.setCurrentText(selected_key)
+                elif all_options:
+                    combo.setCurrentIndex(0)
+                row_layout.addWidget(combo, 1)
+
+                # Remove button
+                remove_button = QPushButton("Remove")
+                remove_button.setMaximumWidth(80)
+
+                def remove():
+                    row_idx, _ = form.getWidgetPosition(row_widget)
+                    form.removeRow(row_idx)
+                    if row_data in row_data_list:
+                        row_data_list.remove(row_data)
+                    if combo in row_combos:
+                        row_combos.remove(combo)
+                    refresh_remove_buttons()
+
+                remove_button.clicked.connect(remove)
+                row_layout.addWidget(remove_button, 0)
+
+                # Insert row into form
+                header_idx, _ = form.getWidgetPosition(header_widget)
+                if row_data_list:
+                    last_idx, _ = form.getWidgetPosition(row_data_list[-1]["widget"])
+                    insert_idx = last_idx + 1
+                else:
+                    insert_idx = header_idx + 1
+
+                form.insertRow(insert_idx, "", row_widget)
+
+                # Store row data
+                row_data = {"widget": row_widget, "remove_button": remove_button}
+                row_data_list.append(row_data)
+                row_combos.append(combo)
+                refresh_remove_buttons()
+
+            # Connect add button if not single-value field
+            if max_rows != 1:
+                add_button.clicked.connect(lambda: add_row())
+
+            # Prefill existing selections
+            if current_keys:
+                for key_name in current_keys:
+                    add_row(key_name)
+            else:
+                # Always at least one empty row
+                add_row()
+
+            # Return enriched dict with color_key_list marker and max_rows if set
+            result_dict = {
+                "widget": header_widget,
+                "color_key_list": True,
+                "rows": row_combos,
+            }
+            if max_rows is not None:
+                result_dict["max_rows"] = max_rows
+
+            return display_name, result_dict
+
+        else:
+            return display_name, {"color_key_list": True, "rows": []}
 
     def create_simple_input(self, setting_dict):
         """Create a line edit input for numeric or string values.
@@ -2589,7 +3408,7 @@ class SettingsFactory:
                 continue
             # Skip path_map, int_group_list, int_list_map, time_interval_map, time_window_map,
             # time_data_map, path_data_map, registry_key_list, format_map, roi_map,
-            # roi_key_list dicts (handled below)
+            # roi_key_list, color_path_map, color_range_map, color_channel_map dicts (handled below)
             if isinstance(value, dict) and (
                 "path_map" in value
                 or "int_group_list" in value
@@ -2603,6 +3422,10 @@ class SettingsFactory:
                 or "format_key_list" in value
                 or "roi_map" in value
                 or "roi_key_list" in value
+                or "color_key_list" in value
+                or "color_path_map" in value
+                or "color_range_map" in value
+                or "color_channel_map" in value
             ):
                 continue
             # Skip sub-inputs of unchecked groups
@@ -2968,9 +3791,243 @@ class SettingsFactory:
                 # Write as list[dict] directly to config_dict["roi"]
                 self.main_window.config_dict["roi"] = result
 
+        # Color-map pass: parse color_path_map, color_range_map, color_channel_map rows
+        # into list[dict] for [[color]] TOML shape, with passthrough merge for
+        # restoration/mask sub-tables. All three groups write to the same config_dict["color"].
+        color_result = []
+        color_seen_names = set()
+
+        # Process all three color map types in one pass
+        for key, value in self.main_window.settings_inputs.items():
+            if isinstance(value, dict) and "color_path_map" in value:
+                # Path embeddings: 16-tuple + passthrough dict
+                for edits, passthrough_data in value["rows"]:
+                    (
+                        name_edit,
+                        mode_combo,
+                        basis_combo,
+                        calibration_mode_combo,
+                        baseline_combo,
+                        data_combo,
+                        rois_edit,
+                        num_segments_edit,
+                        resolution_edit,
+                        threshold_baseline_edit,
+                        threshold_calibration_edit,
+                        reference_label_edit,
+                        ignore_labels_edit,
+                        ignore_baseline_combo,
+                        histogram_weighting_combo,
+                        calibration_folder_edit,
+                    ) = edits
+
+                    name_text = name_edit.text().strip()
+                    if not name_text:
+                        continue
+
+                    # Check for duplicate names across all groups
+                    if name_text in color_seen_names:
+                        self.main_window.print_log(
+                            f"Warning: duplicate color embedding name '{name_text}' skipped during save"
+                        )
+                        continue
+                    color_seen_names.add(name_text)
+
+                    # Start from passthrough data (preserves restoration/mask)
+                    entry = dict(passthrough_data)
+                    entry["type"] = "path"
+                    entry["name"] = name_text
+                    entry["mode"] = mode_combo.currentText().strip()
+                    entry["basis"] = basis_combo.currentText().strip()
+                    entry["calibration_mode"] = calibration_mode_combo.currentText().strip()
+
+                    # baseline/data dropdowns
+                    baseline_text = baseline_combo.currentText().strip()
+                    if baseline_text:
+                        entry["baseline"] = baseline_text
+                    data_text = data_combo.currentText().strip()
+                    if data_text:
+                        entry["data"] = data_text
+
+                    # rois: parse comma-separated list
+                    rois_text = rois_edit.text().strip()
+                    if rois_text:
+                        entry["rois"] = [r.strip() for r in rois_text.split(",") if r.strip()]
+                    else:
+                        entry["rois"] = []
+
+                    # numeric fields
+                    try:
+                        entry["num_segments"] = int(num_segments_edit.text().strip() or "1")
+                    except ValueError:
+                        pass
+                    try:
+                        entry["resolution"] = int(resolution_edit.text().strip() or "51")
+                    except ValueError:
+                        pass
+                    try:
+                        entry["threshold_baseline"] = float(
+                            threshold_baseline_edit.text().strip() or "0.0"
+                        )
+                    except ValueError:
+                        pass
+                    try:
+                        entry["threshold_calibration"] = float(
+                            threshold_calibration_edit.text().strip() or "0.0"
+                        )
+                    except ValueError:
+                        pass
+                    try:
+                        entry["reference_label"] = int(
+                            reference_label_edit.text().strip() or "0"
+                        )
+                    except ValueError:
+                        pass
+
+                    # ignore_labels: comma-separated ints
+                    ignore_labels_text = ignore_labels_edit.text().strip()
+                    if ignore_labels_text:
+                        try:
+                            entry["ignore_labels"] = [
+                                int(x.strip()) for x in ignore_labels_text.split(",")
+                            ]
+                        except ValueError:
+                            pass
+
+                    entry["ignore_baseline_spectrum"] = (
+                        ignore_baseline_combo.currentText().strip()
+                    )
+                    entry["histogram_weighting"] = histogram_weighting_combo.currentText().strip()
+
+                    # calibration_folder (optional)
+                    calibration_folder_text = calibration_folder_edit.text().strip()
+                    if calibration_folder_text:
+                        entry["calibration_folder"] = calibration_folder_text
+
+                    color_result.append(entry)
+
+            elif isinstance(value, dict) and "color_range_map" in value:
+                # Range embeddings: 6-tuple + passthrough dict
+                for edits, passthrough_data in value["rows"]:
+                    (
+                        name_edit,
+                        mode_combo,
+                        basis_combo,
+                        color_space_edit,
+                        range_edit,
+                        calibration_folder_edit,
+                    ) = edits
+
+                    name_text = name_edit.text().strip()
+                    if not name_text:
+                        continue
+
+                    if name_text in color_seen_names:
+                        self.main_window.print_log(
+                            f"Warning: duplicate color embedding name '{name_text}' skipped during save"
+                        )
+                        continue
+                    color_seen_names.add(name_text)
+
+                    entry = dict(passthrough_data)
+                    entry["type"] = "range"
+                    entry["name"] = name_text
+                    entry["mode"] = mode_combo.currentText().strip()
+                    entry["basis"] = basis_combo.currentText().strip()
+                    entry["color_space"] = color_space_edit.text().strip().upper()
+
+                    # range: parse 6 comma-separated floats into 3 [min,max] pairs
+                    range_text = range_edit.text().strip()
+                    if range_text:
+                        try:
+                            tokens = [
+                                t.strip() for t in range_text.split(",") if t.strip()
+                            ]
+                            if len(tokens) == 6:
+                                ranges = []
+                                for i in range(0, 6, 2):
+                                    min_v = (
+                                        None
+                                        if tokens[i].lower() == "none"
+                                        else float(tokens[i])
+                                    )
+                                    max_v = (
+                                        None
+                                        if tokens[i + 1].lower() == "none"
+                                        else float(tokens[i + 1])
+                                    )
+                                    ranges.append([min_v, max_v])
+                                entry["range"] = ranges
+                        except (ValueError, IndexError):
+                            pass
+
+                    calibration_folder_text = calibration_folder_edit.text().strip()
+                    if calibration_folder_text:
+                        entry["calibration_folder"] = calibration_folder_text
+
+                    color_result.append(entry)
+
+            elif isinstance(value, dict) and "color_channel_map" in value:
+                # Channel embeddings: 5-tuple + passthrough dict
+                for edits, passthrough_data in value["rows"]:
+                    (
+                        name_edit,
+                        mode_combo,
+                        color_space_edit,
+                        channel_edit,
+                        calibration_folder_edit,
+                    ) = edits
+
+                    name_text = name_edit.text().strip()
+                    if not name_text:
+                        continue
+
+                    if name_text in color_seen_names:
+                        self.main_window.print_log(
+                            f"Warning: duplicate color embedding name '{name_text}' skipped during save"
+                        )
+                        continue
+                    color_seen_names.add(name_text)
+
+                    entry = dict(passthrough_data)
+                    entry["type"] = "channel"
+                    entry["name"] = name_text
+                    entry["mode"] = mode_combo.currentText().strip()
+                    entry["color_space"] = color_space_edit.text().strip().upper()
+                    entry["channel"] = channel_edit.text().strip().lower()
+
+                    calibration_folder_text = calibration_folder_edit.text().strip()
+                    if calibration_folder_text:
+                        entry["calibration_folder"] = calibration_folder_text
+
+                    color_result.append(entry)
+
+        # Write all color entries to config_dict["color"]
+        if color_result:
+            self.main_window.config_dict["color"] = color_result
+
         # Fourteenth pass: parse roi_key_list rows into list[str] (or single str)
         for key, value in self.main_window.settings_inputs.items():
             if isinstance(value, dict) and "roi_key_list" in value:
+                result = []
+                seen = set()
+                for combo in value["rows"]:
+                    text = combo.currentText().strip()
+                    if text and text not in seen:
+                        result.append(text)
+                        seen.add(text)
+                if value.get("max_rows") == 1:
+                    self.set_value(
+                        self.main_window.config_dict, key, result[0] if result else None
+                    )
+                else:
+                    self.set_value(
+                        self.main_window.config_dict, key, result if result else None
+                    )
+
+        # Fourteenth-and-a-half pass: parse color_key_list rows into list[str] (or single str)
+        for key, value in self.main_window.settings_inputs.items():
+            if isinstance(value, dict) and "color_key_list" in value:
                 result = []
                 seen = set()
                 for combo in value["rows"]:

--- a/src/darsia/presets/workflows/calibration/calibration_color_paths.py
+++ b/src/darsia/presets/workflows/calibration/calibration_color_paths.py
@@ -233,7 +233,7 @@ def collect_existing_calibration_paths_to_delete(path: Path | list[Path]) -> lis
 
     paths_to_delete: list[Path] = []
     if config.color is not None:
-        for embedding in config.color.embeddings.values():
+        for embedding in config.color.resolve_all().values():
             paths_to_delete.append(embedding.calibration_root)
     if config.data is not None and config.data.cache is not None:
         paths_to_delete.append(config.data.cache)

--- a/src/darsia/presets/workflows/config/analysis.py
+++ b/src/darsia/presets/workflows/config/analysis.py
@@ -396,7 +396,12 @@ class AnalysisSegmentationConfig:
 @dataclass
 class AnalysisMassConfig:
     color: "ColorEmbedding | None" = field(
-        default=None, metadata={"name": "Color embedding"}
+        default=None,
+        metadata={
+            "name": "Color embedding",
+            "widget": "color_key_list",
+            "max_rows": 1,
+        },
     )
     """Color embedding identifier used for mass conversion.
 

--- a/src/darsia/presets/workflows/config/calibration.py
+++ b/src/darsia/presets/workflows/config/calibration.py
@@ -20,7 +20,14 @@ if TYPE_CHECKING:
 class CalibrationColorConfig:
     """Config for selecting a color embedding for color calibration."""
 
-    color: "ColorEmbedding | None" = None
+    color: "ColorEmbedding | None" = field(
+        default=None,
+        metadata={
+            "name": "Color embedding",
+            "widget": "color_key_list",
+            "max_rows": 1,
+        },
+    )
 
     def load(
         self,
@@ -50,7 +57,14 @@ class CalibrationColorConfig:
 class CalibrationMassConfig:
     """Config for mass calibration using a selected color embedding."""
 
-    color: "ColorEmbedding | None" = None
+    color: "ColorEmbedding | None" = field(
+        default=None,
+        metadata={
+            "name": "Color embedding",
+            "widget": "color_key_list",
+            "max_rows": 1,
+        },
+    )
     mode: str = "manual"
     fluid: str | None = "co2"
     data_selection: str | list[str] | None = field(

--- a/src/darsia/presets/workflows/config/color_embedding_registry.py
+++ b/src/darsia/presets/workflows/config/color_embedding_registry.py
@@ -390,3 +390,51 @@ class ColorEmbeddingRegistry:
             Dict mapping embedding names to their ColorEmbedding objects.
         """
         return dict(self._embeddings)
+
+
+@dataclass
+class ColorEmbeddingRegistryConfig:
+    """GUI-editable view of the [[color]] TOML array-of-tables split by type.
+
+    This dataclass exists purely for GUI schema introspection and does not replace
+    ColorEmbeddingRegistry, which remains the canonical runtime registry.
+    ColorEmbeddingRegistryConfig fields are never directly loaded or instantiated
+    by the GUI—instead, the GUI reads raw TOML dicts from config_dict["color"]
+    directly and manages three separate multi-row widget groups by type.
+
+    Each field's metadata declares its widget type so the schema introspection
+    system knows to create the corresponding multi-row editor.
+    """
+
+    color_path_embeddings: dict[str, ColorPathEmbedding] = field(
+        default_factory=dict,
+        metadata={
+            "name": "Color Paths",
+            "help": "Color path embeddings for calibration and analysis.",
+            "group": "Color Paths",
+            "widget": "color_path_map",
+        },
+    )
+    """Dict of color path embeddings, keyed by name."""
+
+    color_range_embeddings: dict[str, ColorRangeEmbedding] = field(
+        default_factory=dict,
+        metadata={
+            "name": "Color Ranges",
+            "help": "Color range embeddings (HSV/RGB bounds).",
+            "group": "Color Ranges",
+            "widget": "color_range_map",
+        },
+    )
+    """Dict of color range embeddings, keyed by name."""
+
+    color_channel_embeddings: dict[str, ColorChannelEmbedding] = field(
+        default_factory=dict,
+        metadata={
+            "name": "Color Channels",
+            "help": "Color channel embeddings with optional masks.",
+            "group": "Color Channels",
+            "widget": "color_channel_map",
+        },
+    )
+    """Dict of color channel embeddings, keyed by name."""

--- a/src/darsia/presets/workflows/config/color_embedding_registry.py
+++ b/src/darsia/presets/workflows/config/color_embedding_registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -17,7 +18,7 @@ from darsia.signals.color import (
 )
 
 from .roi_registry import RoiRegistry, _load_roi_key_list
-from .utils import _convert_none, _get_section_from_toml, _validate_choice
+from .utils import _convert_none, _validate_choice
 
 if TYPE_CHECKING:
     from .data_registry import DataRegistry
@@ -218,11 +219,14 @@ def parse_color_channel_embedding(
     return embedding
 
 
+SUPPORTED_COLOR_TYPES = {"path", "range", "channel"}
+
+
 @dataclass
 class ColorEmbeddingRegistry:
-    """Registry of configured color embeddings."""
+    """Registry of configured color embeddings loaded from [[color]] array-of-tables."""
 
-    embeddings: dict[str, ColorEmbedding] = field(default_factory=dict)
+    _embeddings: dict[str, ColorEmbedding] = field(default_factory=dict, repr=False)
 
     def load(
         self,
@@ -233,71 +237,122 @@ class ColorEmbeddingRegistry:
         data_registry: DataRegistry | None = None,
         roi_registry: "RoiRegistry | None" = None,
     ) -> "ColorEmbeddingRegistry":
-        sec = _get_section_from_toml(path, "color")
-        if not isinstance(sec, dict):
-            raise ValueError("[color] must be a table.")
+        """Load color embeddings from [[color]] array-of-tables in TOML.
 
-        self.embeddings = {}
-        seen: set[str] = set()
+        Hand-parses TOML (like FormatRegistry and RoiRegistry) since array-of-tables
+        is not supported by the generic _get_section_from_toml helper.
+
+        Args:
+            path: Path or list of Paths to TOML config file(s).
+            data: Data folder path.
+            results: Results folder path.
+            data_registry: Optional DataRegistry for resolving data references.
+            roi_registry: Optional RoiRegistry for validating ROI references.
+
+        Returns:
+            self
+
+        Raises:
+            ValueError: If the [color] section is not an array-of-tables, if any
+                entry is missing required fields (type, name), or if types/names
+                are invalid or duplicated.
+        """
+        paths = [path] if isinstance(path, Path) else path
+        self._embeddings = {}
         color_root = results / "calibration" / "color" if results is not None else None
 
-        # [color.path.<id>]
-        path_sec = sec.get("path", {})
-        if isinstance(path_sec, dict):
-            for embedding_id, cfg in path_sec.items():
-                self._update_seen(embedding_id, seen)
-                self.embeddings[embedding_id] = parse_color_path_embedding(
-                    cfg=cfg,
-                    embedding_id=embedding_id,
-                    color_root=color_root,
-                    data=data,
-                    data_registry=data_registry,
-                    roi_registry=roi_registry,
+        for p in paths:
+            if not p.exists():
+                continue
+
+            with open(p, "rb") as f:
+                toml_data = tomllib.load(f)
+
+            if "color" not in toml_data:
+                continue
+
+            color_data = toml_data["color"]
+
+            # Strict format: [[color]] is a list, not nested dicts like [color.*]
+            if not isinstance(color_data, list):
+                raise ValueError(
+                    "The [color] section must be an array-of-tables format "
+                    "(use [[color]]), not nested tables."
                 )
 
-        # [color.range.<id>]
-        range_sec = sec.get("range", {})
-        if isinstance(range_sec, dict):
-            for embedding_id, cfg in range_sec.items():
-                self._update_seen(embedding_id, seen)
-                self.embeddings[embedding_id] = parse_color_range_embedding(
-                    cfg=cfg,
-                    embedding_id=embedding_id,
-                    color_root=color_root,
-                    data=data,
-                    data_registry=data_registry,
-                    roi_registry=roi_registry,
-                )
+            for idx, entry in enumerate(color_data):
+                if not isinstance(entry, dict):
+                    raise ValueError(f"[[color]] entry {idx} must be a table/dict.")
 
-        # [color.channel.<id>]
-        channel_sec = sec.get("channel", {})
-        if isinstance(channel_sec, dict):
-            for embedding_id, cfg in channel_sec.items():
-                self._update_seen(embedding_id, seen)
-                self.embeddings[embedding_id] = parse_color_channel_embedding(
-                    cfg=cfg,
-                    embedding_id=embedding_id,
-                    color_root=color_root,
-                    data=data,
-                    data_registry=data_registry,
-                    roi_registry=roi_registry,
-                )
+                # Extract required fields
+                entry_type = entry.get("type")
+                if entry_type is None:
+                    raise ValueError(
+                        f"[[color]] entry {idx} is missing required 'type' field."
+                    )
+
+                entry_name = entry.get("name")
+                if entry_name is None:
+                    raise ValueError(
+                        f"[[color]] entry {idx} is missing required 'name' "
+                        "field (the registry key)."
+                    )
+
+                entry_type = str(entry_type).strip().lower()
+                if entry_type not in SUPPORTED_COLOR_TYPES:
+                    raise ValueError(
+                        f"Unsupported color type '{entry_type}' in [[color]] entry {idx}. "
+                        f"Supported: {sorted(SUPPORTED_COLOR_TYPES)}"
+                    )
+
+                entry_name = str(entry_name).strip()
+                if entry_name in self._embeddings:
+                    raise ValueError(
+                        f"Color embedding name '{entry_name}' is duplicated. "
+                        "Names must be globally unique."
+                    )
+
+                # Extract config (exclude type and name)
+                cfg = {k: v for k, v in entry.items() if k not in ("type", "name")}
+
+                # Dispatch to the appropriate parser based on type
+                if entry_type == "path":
+                    self._embeddings[entry_name] = parse_color_path_embedding(
+                        cfg=cfg,
+                        embedding_id=entry_name,
+                        color_root=color_root,
+                        data=data,
+                        data_registry=data_registry,
+                        roi_registry=roi_registry,
+                    )
+                elif entry_type == "range":
+                    self._embeddings[entry_name] = parse_color_range_embedding(
+                        cfg=cfg,
+                        embedding_id=entry_name,
+                        color_root=color_root,
+                        data=data,
+                        data_registry=data_registry,
+                        roi_registry=roi_registry,
+                    )
+                elif entry_type == "channel":
+                    self._embeddings[entry_name] = parse_color_channel_embedding(
+                        cfg=cfg,
+                        embedding_id=entry_name,
+                        color_root=color_root,
+                        data=data,
+                        data_registry=data_registry,
+                        roi_registry=roi_registry,
+                    )
 
         return self
 
-    def _update_seen(self, embedding_id: str, seen: set[str]) -> None:
-        """Auxiliary method to check for duplicate embedding IDs.
+    def keys(self) -> list[str]:
+        """Return all registered embedding names."""
+        return list(self._embeddings.keys())
 
-        Args:
-            embedding_id: The embedding identifier to check.
-            seen: A set of already seen embedding identifiers. If embedding_id is in
-                this set, a ValueError is raised. Otherwise, embedding_id is added to
-                the set.
-
-        """
-        if embedding_id in seen:
-            raise ValueError(f"Duplicate color embedding identifier '{embedding_id}'.")
-        seen.add(embedding_id)
+    def __contains__(self, name: str) -> bool:
+        """Check if an embedding name is registered (supports 'name in registry')."""
+        return name in self._embeddings
 
     def resolve(self, embedding: str | ColorEmbedding) -> ColorEmbedding:
         """Resolve embedding identifier or object to embedding object.
@@ -305,25 +360,33 @@ class ColorEmbeddingRegistry:
         Args:
             embedding: Either a string identifier of a registered embedding, or a
                 ColorEmbedding object. If an object is provided, it is verified to be
-                registered in self.embeddings.
+                registered in self._embeddings.
 
         Returns:
             The corresponding ColorEmbedding object.
 
         """
         if isinstance(embedding, str):  # embedding_id
-            if embedding not in self.embeddings:
-                available = sorted(self.embeddings.keys())
+            if embedding not in self._embeddings:
+                available = sorted(self._embeddings.keys())
                 raise KeyError(
                     "ColorEmbeddingRegistry: key "
                     f"'{embedding}' not found. Available keys: {available}"
                 )
-            return self.embeddings[embedding]
+            return self._embeddings[embedding]
         else:  # embedding object
-            # Make sure embedding is registered in self.embeddings.
-            if embedding.embedding_id not in self.embeddings:
+            # Make sure embedding is registered in self._embeddings.
+            if embedding.embedding_id not in self._embeddings:
                 raise KeyError(
                     f"ColorEmbeddingRegistry: embedding with id "
                     f"'{embedding.embedding_id}' not found in registry."
                 )
         return embedding
+
+    def resolve_all(self) -> dict[str, ColorEmbedding]:
+        """Return a dict of all registered embeddings (already resolved at load time).
+
+        Returns:
+            Dict mapping embedding names to their ColorEmbedding objects.
+        """
+        return dict(self._embeddings)

--- a/src/darsia/presets/workflows/config/fluidflower_config.py
+++ b/src/darsia/presets/workflows/config/fluidflower_config.py
@@ -190,7 +190,7 @@ class FluidFlowerConfig:
             "roi_registry",
             RoiRegistry(),
             lambda: self.roi_registry.load(path),
-            warn_on_missing=False,
+            warn_on_missing=True,
         )
 
         _load_section(
@@ -243,6 +243,7 @@ class FluidFlowerConfig:
                 color_embedding_registry=self.color,
             ),
             warn_on_missing=True,
+            exception_types=(ValueError, KeyError),
         )
 
         _load_section(

--- a/src/darsia/presets/workflows/mode_resolution.py
+++ b/src/darsia/presets/workflows/mode_resolution.py
@@ -47,10 +47,7 @@ def validate_mode_syntax(
     mode = mode.strip()
     if mode in LEGACY_COLOR_TO_MASS_MODES or mode in SCALAR_PRODUCT_MODES:
         return
-    if (
-        color_embedding_registry is not None
-        and mode in color_embedding_registry.embeddings
-    ):
+    if color_embedding_registry is not None and mode in color_embedding_registry:
         return
     raise ValueError(
         f"Unsupported {key} '{mode}'. Supported modes "
@@ -116,10 +113,7 @@ def resolve_mode_image(
     if mode in LEGACY_COLOR_TO_MASS_MODES:
         return _resolve_legacy_mode(mode, mass_analysis_result)
     # Color embeddings.
-    if (
-        color_embedding_registry is not None
-        and mode in color_embedding_registry.embeddings
-    ):
+    if color_embedding_registry is not None and mode in color_embedding_registry:
         return _resolve_color_mode(
             mode,
             image,

--- a/tests/unit/test_analysis_config.py
+++ b/tests/unit/test_analysis_config.py
@@ -167,12 +167,16 @@ def test_analysis_thresholding_accepts_extended_modes(tmp_path: Path) -> None:
     config_path = _write(
         tmp_path / "config.toml",
         """
-[color.channel.red_channel]
+[[color]]
+type = "channel"
+name = "red_channel"
 mode = "absolute"
 color_space = "RGB"
 channel = "r"
 
-[color.range.green_band]
+[[color]]
+type = "range"
+name = "green_band"
 mode = "relative"
 color_space = "RGB"
 range = [[0.0, 1.0], [0.2, 0.8], [0.0, 1.0]]
@@ -223,7 +227,9 @@ def test_analysis_thresholding_rejects_invalid_color_mode_token(tmp_path: Path) 
     config_path = _write(
         tmp_path / "config.toml",
         """
-[color.channel.red_channel]
+[[color]]
+type = "channel"
+name = "red_channel"
 mode = "absolute"
 color_space = "RGB"
 channel = "r"
@@ -386,7 +392,9 @@ def test_analysis_mass_export_defaults_to_none(tmp_path: Path) -> None:
     config_path = _write(
         tmp_path / "config.toml",
         """
-[color.channel.my_colorpath]
+[[color]]
+type = "channel"
+name = "my_colorpath"
 mode = "absolute"
 basis = "global"
 color_space = "RGB"
@@ -414,7 +422,9 @@ def test_analysis_mass_export_accepts_supported_modes(tmp_path: Path) -> None:
     config_path = _write(
         tmp_path / "config.toml",
         """
-[color.channel.my_colorpath]
+[[color]]
+type = "channel"
+name = "my_colorpath"
 mode = "absolute"
 basis = "global"
 color_space = "RGB"
@@ -447,7 +457,9 @@ def test_analysis_mass_export_rejects_unsupported_modes(tmp_path: Path) -> None:
     config_path = _write(
         tmp_path / "config.toml",
         """
-[color.channel.my_colorpath]
+[[color]]
+type = "channel"
+name = "my_colorpath"
 mode = "absolute"
 basis = "global"
 color_space = "RGB"

--- a/tests/unit/test_calibration_delete.py
+++ b/tests/unit/test_calibration_delete.py
@@ -4,12 +4,13 @@ from darsia.presets.workflows.calibration import calibration_color_paths as modu
 
 
 def _mock_config(calibration_root_1, calibration_root_2, cache):
+    embeddings_dict = {
+        "a": SimpleNamespace(calibration_root=calibration_root_1),
+        "b": SimpleNamespace(calibration_root=calibration_root_2),
+    }
     return SimpleNamespace(
         color=SimpleNamespace(
-            embeddings={
-                "a": SimpleNamespace(calibration_root=calibration_root_1),
-                "b": SimpleNamespace(calibration_root=calibration_root_2),
-            }
+            resolve_all=lambda: embeddings_dict
         ),
         data=SimpleNamespace(cache=cache),
     )

--- a/tests/unit/test_color_embedding_registry.py
+++ b/tests/unit/test_color_embedding_registry.py
@@ -1,0 +1,629 @@
+"""Unit tests for ColorEmbeddingRegistry (array-of-tables [[color]] format)."""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from darsia.presets.workflows.config.color_embedding_registry import (
+    ColorEmbeddingRegistry,
+)
+from darsia.presets.workflows.config.data_registry import DataRegistry
+from darsia.presets.workflows.config.roi import RoiConfig
+from darsia.presets.workflows.config.roi_registry import RoiRegistry
+from darsia.signals.color import (
+    ColorChannelEmbedding,
+    ColorPathEmbedding,
+    ColorRangeEmbedding,
+)
+
+
+def _write_toml(tmp_path: Path, content: str, filename: str = "config.toml") -> Path:
+    """Write TOML content to a temp file and return its path."""
+    p = tmp_path / filename
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(textwrap.dedent(content))
+    return p
+
+
+def _make_registry_with_roi(name: str = "test_roi") -> RoiRegistry:
+    """Create a RoiRegistry with a single ROI for testing."""
+    reg = RoiRegistry()
+    roi = RoiConfig()
+    roi.load({"name": name, "corner_1": [0.1, 0.2], "corner_2": [0.8, 0.9]})
+    reg.register(name, roi)
+    return reg
+
+
+def _make_data_registry(tmp_path: Path) -> DataRegistry:
+    """Create a DataRegistry with dummy baseline and data path entries."""
+    dummy = tmp_path / "dummy.jpg"
+    dummy.touch()
+    sec = {
+        "path_registry": {
+            "baseline_imgs": {"paths": ["dummy.jpg"]},
+            "cal_imgs": {"paths": ["dummy.jpg"]},
+        }
+    }
+    return DataRegistry().load(sec, data_folder=tmp_path)
+
+
+class TestColorEmbeddingRegistryStructuralValidation:
+    """Test structural validation of the [[color]] array-of-tables format."""
+
+    def test_missing_color_section_succeeds_with_empty_registry(self, tmp_path):
+        """If no [color] section exists, registry loads with zero entries."""
+        toml_path = _write_toml(tmp_path, "")
+        registry = ColorEmbeddingRegistry().load(
+            path=toml_path,
+            data=None,
+            results=None,
+        )
+        assert len(registry.keys()) == 0
+
+    def test_color_as_nested_dict_raises_error(self, tmp_path):
+        """[color] as nested tables (not array-of-tables) raises ValueError."""
+        toml_path = _write_toml(
+            tmp_path,
+            """
+            [color.path.test_entry]
+            """,
+        )
+        with pytest.raises(
+            ValueError,
+            match="must be an array-of-tables format.*use \\[\\[color\\]\\]",
+        ):
+            ColorEmbeddingRegistry().load(
+                path=toml_path,
+                data=None,
+                results=None,
+            )
+
+    def test_missing_type_field_raises_error(self, tmp_path):
+        """[[color]] entry without 'type' raises ValueError."""
+        toml_path = _write_toml(
+            tmp_path,
+            """
+            [[color]]
+            name = "no_type"
+            """,
+        )
+        with pytest.raises(ValueError, match="missing required 'type' field"):
+            ColorEmbeddingRegistry().load(
+                path=toml_path,
+                data=None,
+                results=None,
+            )
+
+    def test_missing_name_field_raises_error(self, tmp_path):
+        """[[color]] entry without 'name' raises ValueError."""
+        toml_path = _write_toml(
+            tmp_path,
+            """
+            [[color]]
+            type = "path"
+            """,
+        )
+        with pytest.raises(ValueError, match="missing required 'name'"):
+            ColorEmbeddingRegistry().load(
+                path=toml_path,
+                data=None,
+                results=None,
+            )
+
+    def test_unsupported_type_raises_error(self, tmp_path):
+        """[[color]] entry with unsupported 'type' raises ValueError."""
+        toml_path = _write_toml(
+            tmp_path,
+            """
+            [[color]]
+            type = "unsupported_type"
+            name = "test"
+            """,
+        )
+        with pytest.raises(
+            ValueError,
+            match="Unsupported color type.*Supported:.*channel.*path.*range",
+        ):
+            ColorEmbeddingRegistry().load(
+                path=toml_path,
+                data=None,
+                results=None,
+            )
+
+    def test_duplicate_name_raises_error(self, tmp_path):
+        """Duplicate color embedding names raise ValueError."""
+        toml_path = _write_toml(
+            tmp_path,
+            """
+            [[color]]
+            type = "path"
+            name = "duplicate"
+            mode = "relative"
+            basis = "labels"
+            data = ["cal_imgs"]
+            baseline = "baseline_imgs"
+
+            [[color]]
+            type = "range"
+            name = "duplicate"
+            color_space = "RGB"
+            range = [[0.0, 1.0], [0.0, 1.0], [0.0, 1.0]]
+            """,
+        )
+        data_reg = _make_data_registry(tmp_path)
+        with pytest.raises(ValueError, match="duplicated.*globally unique"):
+            ColorEmbeddingRegistry().load(
+                path=toml_path,
+                data=tmp_path,
+                results=tmp_path,
+                data_registry=data_reg,
+            )
+
+
+class TestColorEmbeddingRegistryEagerValidation:
+    """Test that field validation happens eagerly at .load() time."""
+
+    def test_invalid_calibration_mode_raises_at_load_time(self, tmp_path):
+        """Bad calibration_mode in a path entry raises at .load(), not .resolve()."""
+        toml_path = _write_toml(
+            tmp_path,
+            """
+            [[color]]
+            type = "path"
+            name = "bad_mode"
+            calibration_mode = "invalid_mode"
+            data = ["cal_imgs"]
+            baseline = "baseline_imgs"
+            """,
+        )
+        data_reg = _make_data_registry(tmp_path)
+        with pytest.raises(ValueError, match="calibration_mode.*invalid_mode"):
+            ColorEmbeddingRegistry().load(
+                path=toml_path,
+                data=tmp_path,
+                results=tmp_path,
+                data_registry=data_reg,
+            )
+
+    def test_unknown_roi_key_raises_at_load_time(self, tmp_path):
+        """Unknown ROI key in 'rois' list raises at .load(), not .resolve()."""
+        toml_path = _write_toml(
+            tmp_path,
+            """
+            [[color]]
+            type = "path"
+            name = "bad_roi"
+            rois = ["unknown_roi"]
+            data = ["cal_imgs"]
+            baseline = "baseline_imgs"
+            """,
+        )
+        data_reg = _make_data_registry(tmp_path)
+        roi_reg = _make_registry_with_roi("valid_roi")
+        with pytest.raises(KeyError, match="unknown_roi.*not found"):
+            ColorEmbeddingRegistry().load(
+                path=toml_path,
+                data=tmp_path,
+                results=tmp_path,
+                data_registry=data_reg,
+                roi_registry=roi_reg,
+            )
+
+    def test_missing_required_color_space_raises_at_load_time(self, tmp_path):
+        """Missing 'color_space' in a range entry raises at .load()."""
+        toml_path = _write_toml(
+            tmp_path,
+            """
+            [[color]]
+            type = "range"
+            name = "no_colorspace"
+            range = [[0.0, 1.0], [0.0, 1.0], [0.0, 1.0]]
+            """,
+        )
+        with pytest.raises(ValueError, match="color_space.*required"):
+            ColorEmbeddingRegistry().load(
+                path=toml_path,
+                data=None,
+                results=None,
+            )
+
+
+class TestColorEmbeddingRegistryPathType:
+    """Test successful loading and resolution of type='path' entries."""
+
+    def test_minimal_path_entry_loads(self, tmp_path):
+        """A minimal [[color]] with type='path' loads successfully."""
+        toml_path = _write_toml(
+            tmp_path,
+            """
+            [[color]]
+            type = "path"
+            name = "color_path"
+            data = ["cal_imgs"]
+            baseline = "baseline_imgs"
+            """,
+        )
+        data_reg = _make_data_registry(tmp_path)
+        registry = ColorEmbeddingRegistry().load(
+            path=toml_path,
+            data=tmp_path,
+            results=tmp_path,
+            data_registry=data_reg,
+        )
+        assert "color_path" in registry
+        embedding = registry.resolve("color_path")
+        assert isinstance(embedding, ColorPathEmbedding)
+        assert embedding.embedding_id == "color_path"
+        assert embedding.mode.value == "relative"  # default
+        assert embedding.basis.value == "labels"  # default
+
+    def test_path_entry_with_rois(self, tmp_path):
+        """Path entry with rois list loads and stores them correctly."""
+        toml_path = _write_toml(
+            tmp_path,
+            """
+            [[color]]
+            type = "path"
+            name = "with_rois"
+            rois = ["test_roi"]
+            data = ["cal_imgs"]
+            baseline = "baseline_imgs"
+            """,
+        )
+        data_reg = _make_data_registry(tmp_path)
+        roi_reg = _make_registry_with_roi("test_roi")
+        registry = ColorEmbeddingRegistry().load(
+            path=toml_path,
+            data=tmp_path,
+            results=tmp_path,
+            data_registry=data_reg,
+            roi_registry=roi_reg,
+        )
+        embedding = registry.resolve("with_rois")
+        assert embedding.rois == ["test_roi"]
+
+
+class TestColorEmbeddingRegistryRangeType:
+    """Test successful loading and resolution of type='range' entries."""
+
+    def test_range_entry_loads(self, tmp_path):
+        """A [[color]] with type='range' loads successfully."""
+        toml_path = _write_toml(
+            tmp_path,
+            """
+            [[color]]
+            type = "range"
+            name = "green_range"
+            color_space = "RGB"
+            range = [[0.0, 1.0], [0.2, 0.8], [0.0, 1.0]]
+            """,
+        )
+        registry = ColorEmbeddingRegistry().load(
+            path=toml_path,
+            data=None,
+            results=None,
+        )
+        embedding = registry.resolve("green_range")
+        assert isinstance(embedding, ColorRangeEmbedding)
+        assert embedding.embedding_id == "green_range"
+        assert embedding.color_space == "RGB"
+        assert len(embedding.ranges) == 3
+        assert embedding.ranges[1] == (0.2, 0.8)
+
+
+class TestColorEmbeddingRegistryChannelType:
+    """Test successful loading and resolution of type='channel' entries."""
+
+    def test_channel_entry_loads(self, tmp_path):
+        """A [[color]] with type='channel' loads successfully."""
+        toml_path = _write_toml(
+            tmp_path,
+            """
+            [[color]]
+            type = "channel"
+            name = "red_channel"
+            color_space = "RGB"
+            channel = "r"
+            """,
+        )
+        registry = ColorEmbeddingRegistry().load(
+            path=toml_path,
+            data=None,
+            results=None,
+        )
+        embedding = registry.resolve("red_channel")
+        assert isinstance(embedding, ColorChannelEmbedding)
+        assert embedding.embedding_id == "red_channel"
+        assert embedding.color_space == "RGB"
+        assert embedding.channel == "r"
+
+    def test_channel_with_mask_loads(self, tmp_path):
+        """Channel entry with an inline mask sub-table loads successfully."""
+        toml_path = _write_toml(
+            tmp_path,
+            """
+            [[color]]
+            type = "channel"
+            name = "masked_channel"
+            color_space = "RGB"
+            channel = "r"
+            mask = { color_space = "HSV", range = [[0.2, 0.4], [0.5, 1.0], [0.0, 1.0]] }
+            """,
+        )
+        registry = ColorEmbeddingRegistry().load(
+            path=toml_path,
+            data=None,
+            results=None,
+        )
+        embedding = registry.resolve("masked_channel")
+        assert embedding.mask_embedding is not None
+        assert isinstance(embedding.mask_embedding, ColorRangeEmbedding)
+        assert embedding.mask_embedding.color_space == "HSV"
+
+
+class TestColorEmbeddingRegistryMethods:
+    """Test registry query methods: resolve_all, keys, __contains__."""
+
+    def test_keys_returns_all_names(self, tmp_path):
+        """keys() returns a list of all registered embedding names."""
+        toml_path = _write_toml(
+            tmp_path,
+            """
+            [[color]]
+            type = "path"
+            name = "path_emb"
+            data = ["cal_imgs"]
+            baseline = "baseline_imgs"
+
+            [[color]]
+            type = "range"
+            name = "range_emb"
+            color_space = "RGB"
+            range = [[0.0, 1.0], [0.0, 1.0], [0.0, 1.0]]
+
+            [[color]]
+            type = "channel"
+            name = "channel_emb"
+            color_space = "RGB"
+            channel = "r"
+            """,
+        )
+        data_reg = _make_data_registry(tmp_path)
+        registry = ColorEmbeddingRegistry().load(
+            path=toml_path,
+            data=tmp_path,
+            results=tmp_path,
+            data_registry=data_reg,
+        )
+        keys = registry.keys()
+        assert len(keys) == 3
+        assert set(keys) == {"path_emb", "range_emb", "channel_emb"}
+
+    def test_contains_operator(self, tmp_path):
+        """The 'in' operator works on registry (uses __contains__)."""
+        toml_path = _write_toml(
+            tmp_path,
+            """
+            [[color]]
+            type = "path"
+            name = "exists"
+            data = ["cal_imgs"]
+            baseline = "baseline_imgs"
+            """,
+        )
+        data_reg = _make_data_registry(tmp_path)
+        registry = ColorEmbeddingRegistry().load(
+            path=toml_path,
+            data=tmp_path,
+            results=tmp_path,
+            data_registry=data_reg,
+        )
+        assert "exists" in registry
+        assert "does_not_exist" not in registry
+
+    def test_resolve_all_returns_dict(self, tmp_path):
+        """resolve_all() returns a dict of all registered embeddings."""
+        toml_path = _write_toml(
+            tmp_path,
+            """
+            [[color]]
+            type = "path"
+            name = "emb1"
+            data = ["cal_imgs"]
+            baseline = "baseline_imgs"
+
+            [[color]]
+            type = "range"
+            name = "emb2"
+            color_space = "RGB"
+            range = [[0.0, 1.0], [0.0, 1.0], [0.0, 1.0]]
+            """,
+        )
+        data_reg = _make_data_registry(tmp_path)
+        registry = ColorEmbeddingRegistry().load(
+            path=toml_path,
+            data=tmp_path,
+            results=tmp_path,
+            data_registry=data_reg,
+        )
+        all_embeddings = registry.resolve_all()
+        assert len(all_embeddings) == 2
+        assert "emb1" in all_embeddings
+        assert "emb2" in all_embeddings
+        assert isinstance(all_embeddings["emb1"], ColorPathEmbedding)
+        assert isinstance(all_embeddings["emb2"], ColorRangeEmbedding)
+
+
+class TestColorEmbeddingRegistryResolve:
+    """Test the resolve() method."""
+
+    def test_resolve_by_name_returns_embedding(self, tmp_path):
+        """resolve(name) returns the matching ColorEmbedding."""
+        toml_path = _write_toml(
+            tmp_path,
+            """
+            [[color]]
+            type = "path"
+            name = "test"
+            data = ["cal_imgs"]
+            baseline = "baseline_imgs"
+            """,
+        )
+        data_reg = _make_data_registry(tmp_path)
+        registry = ColorEmbeddingRegistry().load(
+            path=toml_path,
+            data=tmp_path,
+            results=tmp_path,
+            data_registry=data_reg,
+        )
+        embedding = registry.resolve("test")
+        assert isinstance(embedding, ColorPathEmbedding)
+
+    def test_resolve_unknown_name_raises_keyerror(self, tmp_path):
+        """resolve(unknown_name) raises KeyError with available keys."""
+        toml_path = _write_toml(
+            tmp_path,
+            """
+            [[color]]
+            type = "path"
+            name = "exists"
+            data = ["cal_imgs"]
+            baseline = "baseline_imgs"
+            """,
+        )
+        data_reg = _make_data_registry(tmp_path)
+        registry = ColorEmbeddingRegistry().load(
+            path=toml_path,
+            data=tmp_path,
+            results=tmp_path,
+            data_registry=data_reg,
+        )
+        with pytest.raises(KeyError, match="not found.*exists"):
+            registry.resolve("unknown")
+
+    def test_resolve_embedding_object_registered(self, tmp_path):
+        """resolve(embedding_object) verifies it's registered and returns it."""
+        toml_path = _write_toml(
+            tmp_path,
+            """
+            [[color]]
+            type = "path"
+            name = "test"
+            data = ["cal_imgs"]
+            baseline = "baseline_imgs"
+            """,
+        )
+        data_reg = _make_data_registry(tmp_path)
+        registry = ColorEmbeddingRegistry().load(
+            path=toml_path,
+            data=tmp_path,
+            results=tmp_path,
+            data_registry=data_reg,
+        )
+        embedding = registry.resolve("test")
+        # Resolve it again via object reference
+        result = registry.resolve(embedding)
+        assert result is embedding
+
+    def test_resolve_unregistered_embedding_object_raises_keyerror(self, tmp_path):
+        """resolve(unregistered_embedding_object) raises KeyError."""
+        toml_path = _write_toml(
+            tmp_path,
+            """
+            [[color]]
+            type = "path"
+            name = "exists"
+            data = ["cal_imgs"]
+            baseline = "baseline_imgs"
+            """,
+        )
+        data_reg = _make_data_registry(tmp_path)
+        registry = ColorEmbeddingRegistry().load(
+            path=toml_path,
+            data=tmp_path,
+            results=tmp_path,
+            data_registry=data_reg,
+        )
+        # Create an unregistered embedding
+        unregistered = ColorPathEmbedding(
+            embedding_id="not_registered",
+            mode="relative",
+            basis="labels",
+            calibration_root=None,
+            rois=[],
+        )
+        with pytest.raises(KeyError, match="not found in registry"):
+            registry.resolve(unregistered)
+
+
+class TestColorEmbeddingRegistryMultipleFiles:
+    """Test loading from multiple TOML files."""
+
+    def test_load_multiple_files_merges_entries(self, tmp_path):
+        """Loading from multiple files merges all [[color]] entries."""
+        file1_path = _write_toml(
+            tmp_path,
+            """
+            [[color]]
+            type = "path"
+            name = "from_file1"
+            data = ["cal_imgs"]
+            baseline = "baseline_imgs"
+            """,
+            "file1.toml",
+        )
+        file2_path = _write_toml(
+            tmp_path,
+            """
+            [[color]]
+            type = "range"
+            name = "from_file2"
+            color_space = "RGB"
+            range = [[0.0, 1.0], [0.0, 1.0], [0.0, 1.0]]
+            """,
+            "file2.toml",
+        )
+        data_reg = _make_data_registry(tmp_path)
+        registry = ColorEmbeddingRegistry().load(
+            path=[file1_path, file2_path],
+            data=tmp_path,
+            results=tmp_path,
+            data_registry=data_reg,
+        )
+        assert len(registry.keys()) == 2
+        assert "from_file1" in registry
+        assert "from_file2" in registry
+
+    def test_duplicate_names_across_files_raise_error(self, tmp_path):
+        """Same embedding name in different files raises ValueError."""
+        file1_path = _write_toml(
+            tmp_path,
+            """
+            [[color]]
+            type = "path"
+            name = "duplicate"
+            data = ["cal_imgs"]
+            baseline = "baseline_imgs"
+            """,
+            "file1.toml",
+        )
+        file2_path = _write_toml(
+            tmp_path,
+            """
+            [[color]]
+            type = "range"
+            name = "duplicate"
+            color_space = "RGB"
+            range = [[0.0, 1.0], [0.0, 1.0], [0.0, 1.0]]
+            """,
+            "file2.toml",
+        )
+        data_reg = _make_data_registry(tmp_path)
+        with pytest.raises(ValueError, match="duplicated.*globally unique"):
+            ColorEmbeddingRegistry().load(
+                path=[file1_path, file2_path],
+                data=tmp_path,
+                results=tmp_path,
+                data_registry=data_reg,
+            )

--- a/tests/unit/test_color_paths_config.py
+++ b/tests/unit/test_color_paths_config.py
@@ -50,15 +50,17 @@ def _make_data_registry(tmp_path: Path) -> DataRegistry:
 
 
 def _minimal_color_path_embedding_toml(extra: str = "", rois_line: str = "") -> str:
-    """Return a minimal [color.path.*] TOML section using registry references.
+    """Return a minimal [[color]] array-of-tables TOML using registry references.
 
     Args:
-        extra: Additional TOML lines to insert inside [color.path.*].
+        extra: Additional TOML lines to insert inside [[color]].
         rois_line: A ``rois = ...`` line to inject (empty → key absent).
     """
     return textwrap.dedent(
         f"""\
-[color.path.default]
+[[color]]
+type = "path"
+name = "default"
 baseline = "baseline_imgs"
 data     = "cal_imgs"
 {rois_line}

--- a/tests/unit/test_mode_resolution.py
+++ b/tests/unit/test_mode_resolution.py
@@ -1,3 +1,4 @@
+import textwrap
 from pathlib import Path
 
 import numpy as np
@@ -13,10 +14,8 @@ from darsia.presets.workflows.mode_resolution import (
 )
 from darsia.presets.workflows.segmentation_contours import SimpleSegmentation
 from darsia.signals.color import (
-    ColorChannelEmbedding,
     ColorEmbeddingBasis,
     ColorEmbeddingRuntime,
-    ColorRangeEmbedding,
 )
 
 
@@ -37,7 +36,14 @@ def _runtime(baseline: darsia.OpticalImage):
     return ColorEmbeddingRuntime(rig=_Rig(baseline))
 
 
-def test_resolve_color_channel_by_registry_key() -> None:
+def _registry_from_toml(tmp_path: Path, toml_text: str) -> ColorEmbeddingRegistry:
+    """Load ColorEmbeddingRegistry from in-memory [[color]] TOML fixture."""
+    p = tmp_path / "config.toml"
+    p.write_text(textwrap.dedent(toml_text))
+    return ColorEmbeddingRegistry().load(path=p, data=None, results=None)
+
+
+def test_resolve_color_channel_by_registry_key(tmp_path: Path) -> None:
     arr = (
         np.array(
             [
@@ -49,17 +55,15 @@ def test_resolve_color_channel_by_registry_key() -> None:
         / 255.0
     )  # Apply scaling to [0,1] range for RGB mode
     img = _optical_image(arr)
-    registry = ColorEmbeddingRegistry(
-        embeddings={
-            "red_channel": ColorChannelEmbedding(
-                embedding_id="red_channel",
-                mode=darsia.ColorMode.ABSOLUTE,
-                basis=ColorEmbeddingBasis.GLOBAL,
-                calibration_root=Path("."),
-                color_space="RGB",
-                channel="r",
-            )
-        }
+    registry = _registry_from_toml(
+        tmp_path,
+        """
+        [[color]]
+        type = "channel"
+        name = "red_channel"
+        color_space = "RGB"
+        channel = "r"
+        """,
     )
     signal = resolve_mode_image(
         "red_channel",
@@ -80,20 +84,18 @@ def test_resolve_color_mode_rejects_invalid_token() -> None:
         resolve_mode_image("color.rgb.r", img)
 
 
-def test_resolve_color_range_hsv_binary_mask() -> None:
+def test_resolve_color_range_hsv_binary_mask(tmp_path: Path) -> None:
     arr = np.array([[[255, 0, 0], [0, 255, 0], [0, 0, 255]]], dtype=np.uint8)
     img = _optical_image(arr)
-    registry = ColorEmbeddingRegistry(
-        embeddings={
-            "custom_range": ColorRangeEmbedding(
-                embedding_id="custom_range",
-                mode=darsia.ColorMode.ABSOLUTE,
-                basis=ColorEmbeddingBasis.GLOBAL,
-                calibration_root=Path("."),
-                color_space="HSV",
-                ranges=[(0.2, 0.4), (0.5, None), (0.8, None)],
-            )
-        }
+    registry = _registry_from_toml(
+        tmp_path,
+        """
+        [[color]]
+        type = "range"
+        name = "custom_range"
+        color_space = "HSV"
+        range = [[0.2, 0.4], [0.5, "None"], [0.8, "None"]]
+        """,
     )
     mask = resolve_mode_image(
         "custom_range",
@@ -107,20 +109,20 @@ def test_resolve_color_range_hsv_binary_mask() -> None:
     )
 
 
-def test_simple_segmentation_supports_color_mode_without_mass_inputs() -> None:
+def test_simple_segmentation_supports_color_mode_without_mass_inputs(
+    tmp_path: Path,
+) -> None:
     arr = np.array([[[0, 0, 0], [255, 0, 0]]], dtype=np.uint8)
     img = _optical_image(arr)
-    registry = ColorEmbeddingRegistry(
-        embeddings={
-            "red_channel": ColorChannelEmbedding(
-                embedding_id="red_channel",
-                mode=darsia.ColorMode.ABSOLUTE,
-                basis=ColorEmbeddingBasis.GLOBAL,
-                calibration_root=Path("."),
-                color_space="RGB",
-                channel="r",
-            )
-        }
+    registry = _registry_from_toml(
+        tmp_path,
+        """
+        [[color]]
+        type = "channel"
+        name = "red_channel"
+        color_space = "RGB"
+        channel = "r"
+        """,
     )
     segmentation = SimpleSegmentation(mode="red_channel", threshold=0.5)
     mask = segmentation(

--- a/tests/unit/test_workflow_utils_config.py
+++ b/tests/unit/test_workflow_utils_config.py
@@ -76,7 +76,9 @@ folder = "{data_folder.as_posix()}"
 baseline = "baseline.jpg"
 results = "{(tmp_path / "results").as_posix()}"
 
-[color.channel.red_channel]
+[[color]]
+type = "channel"
+name = "red_channel"
 mode = "absolute"
 basis = "global"
 color_space = "RGB"


### PR DESCRIPTION
This pull request introduces a major refactor to how color embeddings are configured, loaded, and introspected in the Darsia workflow system. The configuration format for color embeddings in TOML files is migrated from a nested-table structure (e.g., `[color.channel.*]`) to a unified array-of-tables format (`[[color]]`). The runtime registry and GUI schema are updated accordingly, and all related validation, loading, and test code is adapted to support this new structure. Additionally, the GUI schema introspection is improved with new metadata for color embedding fields, and error handling is made more robust.

Key changes include:

**Color Embedding Registry Refactor:**

* The `ColorEmbeddingRegistry` now loads color embeddings from a TOML `[[color]]` array-of-tables, supporting strict validation of types and names, and dispatches to the correct embedding parser based on the `type` field. Duplicate names and invalid types are now explicitly rejected. The registry now stores embeddings in a private `_embeddings` dict and exposes new methods for key lookup and resolution. [[1]](diffhunk://#diff-cb241b325b4988e508d68dcca7253c39b8ae090f8af976b06b095f544307d57aR222-R229) [[2]](diffhunk://#diff-cb241b325b4988e508d68dcca7253c39b8ae090f8af976b06b095f544307d57aL236-R340) [[3]](diffhunk://#diff-cb241b325b4988e508d68dcca7253c39b8ae090f8af976b06b095f544307d57aL288-R440)
* The legacy `_get_section_from_toml` helper is no longer used for color embeddings, as the new format is not compatible.
* The registry now provides a `resolve_all()` method for retrieving all loaded embeddings, which is used in downstream code.
* All code and tests referencing the old `[color.channel.*]`, `[color.range.*]`, and `[color.path.*]` TOML sections are updated to use the new `[[color]]` format. [[1]](diffhunk://#diff-e4bb267ab720e9c5e6fe4387ae67ceed84d7b64d0856ea15ac0e0a30131fcc85L170-R179) [[2]](diffhunk://#diff-e4bb267ab720e9c5e6fe4387ae67ceed84d7b64d0856ea15ac0e0a30131fcc85L226-R232) [[3]](diffhunk://#diff-e4bb267ab720e9c5e6fe4387ae67ceed84d7b64d0856ea15ac0e0a30131fcc85L389-R397) [[4]](diffhunk://#diff-e4bb267ab720e9c5e6fe4387ae67ceed84d7b64d0856ea15ac0e0a30131fcc85L417-R427) [[5]](diffhunk://#diff-e4bb267ab720e9c5e6fe4387ae67ceed84d7b64d0856ea15ac0e0a30131fcc85L450-R462) [[6]](diffhunk://#diff-6880c034542ec04754d64f2a8a83fe0a78e8724a38f0efd189fa307cef78944cL53-R63)

**GUI Schema Introspection and Config Classes:**

* A new `ColorEmbeddingRegistryConfig` dataclass is introduced for GUI schema introspection, providing grouped fields for color path, range, and channel embeddings, each with widget metadata for the GUI editor. [[1]](diffhunk://#diff-cb241b325b4988e508d68dcca7253c39b8ae090f8af976b06b095f544307d57aL288-R440) [[2]](diffhunk://#diff-9a3a56645656566550fd9a2d83b6eab7259e5efb4bf4c095d10e82e52c8042a0R10-R12) [[3]](diffhunk://#diff-9a3a56645656566550fd9a2d83b6eab7259e5efb4bf4c095d10e82e52c8042a0R34) [[4]](diffhunk://#diff-9a3a56645656566550fd9a2d83b6eab7259e5efb4bf4c095d10e82e52c8042a0R60)
* The `AnalysisMassConfig`, `CalibrationColorConfig`, and `CalibrationMassConfig` dataclasses now include widget metadata for their `color` fields, improving GUI rendering and editing. [[1]](diffhunk://#diff-9e5bcb868517951123f6875d8e40cb9bfd54020ccd5362f4771fa786cdde13c6L399-R404) [[2]](diffhunk://#diff-a91d1033f4ffc3ad2cdc08da326b2048f635085c8d936b7e8a389c9e485e3d2bL23-R30) [[3]](diffhunk://#diff-a91d1033f4ffc3ad2cdc08da326b2048f635085c8d936b7e8a389c9e485e3d2bL53-R67)

**Validation, Error Handling, and Downstream Usage:**

* All downstream code and tests that reference color embeddings now use the new registry API (`in registry` and `resolve_all()`) instead of direct dict access. [[1]](diffhunk://#diff-27cb1fd4b276e055b8cdbbe583ee0d96bec5feb385b52274082238a327d6b016L50-R50) [[2]](diffhunk://#diff-27cb1fd4b276e055b8cdbbe583ee0d96bec5feb385b52274082238a327d6b016L119-R116) [[3]](diffhunk://#diff-bc272716e062fa670c081117b5365d0715f9303f7a6ff96c50e18e7e41bca3e4L236-R236)
* Improved error handling in the main config loader: missing ROI/color registry sections now raise exceptions by default, and exception types are explicitly declared. [[1]](diffhunk://#diff-343f047efb105e056f5dd61a916ed5ac7984d2ab68f73cb9a39561fb383ece7eL193-R193) [[2]](diffhunk://#diff-343f047efb105e056f5dd61a916ed5ac7984d2ab68f73cb9a39561fb383ece7eR246)

These changes modernize and standardize color embedding configuration, improve validation and error messaging, and provide a more robust and user-friendly interface for both runtime and GUI editing.

**References:**  
[[1]](diffhunk://#diff-cb241b325b4988e508d68dcca7253c39b8ae090f8af976b06b095f544307d57aR222-R229) [[2]](diffhunk://#diff-cb241b325b4988e508d68dcca7253c39b8ae090f8af976b06b095f544307d57aL236-R340) [[3]](diffhunk://#diff-cb241b325b4988e508d68dcca7253c39b8ae090f8af976b06b095f544307d57aL288-R440) [[4]](diffhunk://#diff-9a3a56645656566550fd9a2d83b6eab7259e5efb4bf4c095d10e82e52c8042a0R10-R12) [[5]](diffhunk://#diff-9a3a56645656566550fd9a2d83b6eab7259e5efb4bf4c095d10e82e52c8042a0R34) [[6]](diffhunk://#diff-9a3a56645656566550fd9a2d83b6eab7259e5efb4bf4c095d10e82e52c8042a0R60) [[7]](diffhunk://#diff-9e5bcb868517951123f6875d8e40cb9bfd54020ccd5362f4771fa786cdde13c6L399-R404) [[8]](diffhunk://#diff-a91d1033f4ffc3ad2cdc08da326b2048f635085c8d936b7e8a389c9e485e3d2bL23-R30) [[9]](diffhunk://#diff-a91d1033f4ffc3ad2cdc08da326b2048f635085c8d936b7e8a389c9e485e3d2bL53-R67) [[10]](diffhunk://#diff-27cb1fd4b276e055b8cdbbe583ee0d96bec5feb385b52274082238a327d6b016L50-R50) [[11]](diffhunk://#diff-27cb1fd4b276e055b8cdbbe583ee0d96bec5feb385b52274082238a327d6b016L119-R116) [[12]](diffhunk://#diff-bc272716e062fa670c081117b5365d0715f9303f7a6ff96c50e18e7e41bca3e4L236-R236) [[13]](diffhunk://#diff-e4bb267ab720e9c5e6fe4387ae67ceed84d7b64d0856ea15ac0e0a30131fcc85L170-R179) [[14]](diffhunk://#diff-e4bb267ab720e9c5e6fe4387ae67ceed84d7b64d0856ea15ac0e0a30131fcc85L226-R232) [[15]](diffhunk://#diff-e4bb267ab720e9c5e6fe4387ae67ceed84d7b64d0856ea15ac0e0a30131fcc85L389-R397) [[16]](diffhunk://#diff-e4bb267ab720e9c5e6fe4387ae67ceed84d7b64d0856ea15ac0e0a30131fcc85L417-R427) [[17]](diffhunk://#diff-e4bb267ab720e9c5e6fe4387ae67ceed84d7b64d0856ea15ac0e0a30131fcc85L450-R462) [[18]](diffhunk://#diff-6880c034542ec04754d64f2a8a83fe0a78e8724a38f0efd189fa307cef78944cL53-R63) [[19]](diffhunk://#diff-343f047efb105e056f5dd61a916ed5ac7984d2ab68f73cb9a39561fb383ece7eL193-R193) [[20]](diffhunk://#diff-343f047efb105e056f5dd61a916ed5ac7984d2ab68f73cb9a39561fb383ece7eR246)