### PR TITLE
Entrypoint and installable for gui

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,29 +69,36 @@ pip install .[dev]
 conda install -c conda-forge petsc petsc4py
 ```
 See also `conda_env.yaml` for a complete conda environment.
-## Usage
 
-The following Python script can be applied to the test image in the examples/images folder.
 
-```python
-import numpy as np
+## GUI
 
-# Create a darsia Image: An image that also contains information of physical entities
-image = darsia.imread("images/baseline.jpg", width=2.8, height=1.5)
+The DarSIA GUI provides an interactive interface for image analysis workflows.
 
-# Use the show method to take a look at the imported image.
-image.show()
+### Running the GUI
 
-# Copy the image and adds a grid on top of it.
-grid_image = image.add_grid(dx=0.1, dy=0.1)
-grid_image.show()
-
-# Extract region of interest (ROI) from image (box defined by two corners):
-ROI_image = image.subregion(coordinates=np.array([[1.5, 0], [2.8, 0.7]]))
-ROI_image.show()
+```bash
+uv run darsia
 ```
 
-Furthermore, we encourage any user to checkout the examples in the examples folder and the jupyter notebooks in the examples/notebooks folder.
+**Note:** `uv run python -m darsia.gui` is also supported and equivalent to the command above.
+
+### Desktop Integration (Optional)
+
+To make DarSIA appear in your Linux application menu or Windows Start Menu:
+
+```bash
+uv run darsia-install-desktop
+```
+
+To remove the desktop entry:
+
+```bash
+uv run darsia-install-desktop --uninstall
+```
+
+**Note:** On Windows, this feature requires `pywin32`, which is automatically installed when syncing the `darsia` package on Windows systems.
+
 
 ## Developing DarSIA
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,13 +58,21 @@ dependencies = [
   "toml",
   "PySide6",
   "qtawesome",
-  "psutil"
+  "psutil",
+  "pywin32; sys_platform == 'win32'"
 ]
 
 [project.urls]
 Homepage = "https://github.com/pmgbergen/DarSIA"
 Repository = "https://github.com/pmgbergen/DarSIA.git"
 Issues = "https://github.com/pmgbergen/DarSIA/issues"
+
+# ── Entry points ──────────────────────────────────────────────────────────────
+[project.gui-scripts]
+darsia = "darsia.gui.__main__:main"
+
+[project.scripts]
+darsia-install-desktop = "darsia.gui.desktop_integration:main"
 
 # ── Optional dependencies (replaces extras_require in setup.py) ───────────────
 [project.optional-dependencies]

--- a/src/darsia/gui/__main__.py
+++ b/src/darsia/gui/__main__.py
@@ -4,6 +4,8 @@ Run the GUI using one of the following methods:
 
 1. From anywhere (recommended):
     python -m darsia.gui
+    or
+    uv run darsia
 
 2. From the darsia.gui directory:
     python __main__.py
@@ -14,7 +16,13 @@ from PySide6.QtWidgets import QApplication
 from .ui.main_window import MainWindow
 from .ui.theme import apply_theme, get_theme
 
-if __name__ == "__main__":
+
+def main() -> None:
+    """Initialize and run the DarSIA GUI application.
+
+    Creates a QApplication, applies the theme, instantiates MainWindow,
+    and starts the event loop.
+    """
     app = QApplication()
     app.setOrganizationName("DarSIA")
     app.setApplicationName("DarSIA GUI")
@@ -22,3 +30,7 @@ if __name__ == "__main__":
     window = MainWindow()
     window.show()
     app.exec()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/darsia/gui/desktop_integration.py
+++ b/src/darsia/gui/desktop_integration.py
@@ -1,0 +1,222 @@
+r"""Desktop integration for DarSIA GUI — platform-specific shortcut/menu entry installation.
+
+Provides:
+- Linux: .desktop file installation in ~/.local/share/applications/
+- Windows: .lnk shortcut installation in %APPDATA%\Microsoft\Windows\Start Menu\Programs\
+- Both: icon copying/generation, uninstall support, no-admin-required per-user setup
+
+Uses sys.executable-relative resolution to locate the 'darsia' command, avoiding
+any custom virtualenv discovery logic.
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+
+def _get_darsia_executable() -> Path:
+    """Resolve the absolute path to the 'darsia' console script.
+
+    Returns the sibling script in the same bin/Scripts directory as the current
+    interpreter. This is guaranteed to exist after 'uv sync' picks up the
+    [project.gui-scripts] entry point.
+
+    On Windows: sys.executable.parent / "darsia.exe"
+    On Linux/macOS: sys.executable.parent / "darsia"
+    """
+    bin_dir = Path(sys.executable).parent
+    script_name = "darsia.exe" if sys.platform == "win32" else "darsia"
+    return bin_dir / script_name
+
+
+def _get_icon_path() -> Path:
+    """Get the path to the DarSIA logo PNG within the darsia package.
+
+    Returns the absolute path to the installed package's logo, relative to
+    the desktop_integration.py module location (darsia/gui/desktop_integration.py).
+    The icon is at darsia/presets/workflows/interface/DarSIA_Horisontal_Positiv_part.png.
+    """
+    module_dir = Path(__file__).parent
+    return (module_dir / "../presets/workflows/interface/DarSIA_Horisontal_Positiv_part.png").resolve()
+
+
+def _ensure_icon_exists() -> bool:
+    """Verify the icon file exists in the installed package.
+
+    Returns True if found, False otherwise.
+    """
+    icon = _get_icon_path()
+    return icon.exists()
+
+
+def _install_linux() -> None:
+    """Install a .desktop entry for DarSIA in the Linux application menu.
+
+    Creates ~/.local/share/applications/darsia.desktop and copies the icon to
+    ~/.local/share/icons/hicolor/256x256/apps/darsia.png.
+
+    Uses $XDG_DATA_HOME if set, otherwise defaults to ~/.local/share.
+    Requires no admin privileges.
+    """
+    from PIL import Image
+
+    xdg_data_home = os.environ.get("XDG_DATA_HOME", str(Path.home() / ".local" / "share"))
+    applications_dir = Path(xdg_data_home) / "applications"
+    icons_dir = Path(xdg_data_home) / "icons" / "hicolor" / "256x256" / "apps"
+
+    applications_dir.mkdir(parents=True, exist_ok=True)
+    icons_dir.mkdir(parents=True, exist_ok=True)
+
+    darsia_exe = _get_darsia_executable()
+    desktop_path = applications_dir / "darsia.desktop"
+    icon_path = icons_dir / "darsia.png"
+
+    desktop_content = f"""[Desktop Entry]
+Type=Application
+Name=DarSIA GUI
+Comment=Darcy scale image analysis toolbox
+Exec={darsia_exe}
+Icon=darsia
+Categories=Science;Graphics;
+Terminal=false
+"""
+    desktop_path.write_text(desktop_content)
+    print(f"✓ Created .desktop entry: {desktop_path}")
+
+    if _ensure_icon_exists():
+        src_icon = _get_icon_path()
+        img = Image.open(src_icon)
+        img_resized = img.resize((256, 256), Image.Resampling.LANCZOS)
+        img_resized.save(icon_path)
+        print(f"✓ Copied icon: {icon_path}")
+    else:
+        print("! Warning: icon file not found; .desktop entry created without icon")
+
+
+def _uninstall_linux() -> None:
+    """Remove the DarSIA .desktop entry and icon from Linux application menu."""
+    xdg_data_home = os.environ.get("XDG_DATA_HOME", str(Path.home() / ".local" / "share"))
+    desktop_path = Path(xdg_data_home) / "applications" / "darsia.desktop"
+    icon_path = Path(xdg_data_home) / "icons" / "hicolor" / "256x256" / "apps" / "darsia.png"
+
+    removed = False
+    if desktop_path.exists():
+        desktop_path.unlink()
+        print(f"✓ Removed .desktop entry: {desktop_path}")
+        removed = True
+
+    if icon_path.exists():
+        icon_path.unlink()
+        print(f"✓ Removed icon: {icon_path}")
+        removed = True
+
+    if not removed:
+        print("ℹ No desktop entry found; nothing to uninstall")
+
+
+def _install_windows() -> None:
+    r"""Install a Start Menu shortcut for DarSIA on Windows.
+
+    Creates %APPDATA%\Microsoft\Windows\Start Menu\Programs\DarSIA GUI.lnk
+    pointing to the 'darsia.exe' console script, with a converted .ico icon.
+
+    Requires pywin32; uses only per-user Start Menu (no admin required).
+    """
+    import tempfile
+
+    import win32com.client  # noqa: F401; imported to trigger ImportError if unavailable
+
+    from PIL import Image
+
+    appdata = Path(os.environ.get("APPDATA", str(Path.home() / "AppData" / "Roaming")))
+    start_menu_dir = appdata / "Microsoft" / "Windows" / "Start Menu" / "Programs"
+    start_menu_dir.mkdir(parents=True, exist_ok=True)
+
+    darsia_exe = _get_darsia_executable()
+    shortcut_path = start_menu_dir / "DarSIA GUI.lnk"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        ico_path = Path(tmpdir) / "darsia.ico"
+
+        if _ensure_icon_exists():
+            src_icon = _get_icon_path()
+            img = Image.open(src_icon)
+            img_resized = img.resize((256, 256), Image.Resampling.LANCZOS)
+            img_resized.save(ico_path, "ICO")
+            print(f"✓ Generated icon: {ico_path}")
+        else:
+            print("! Warning: icon file not found; shortcut created without icon")
+
+        shell = win32com.client.Dispatch("WScript.Shell")  # noqa: F821
+        shortcut = shell.CreateShortcut(str(shortcut_path))
+        shortcut.TargetPath = str(darsia_exe)
+        shortcut.WorkingDirectory = str(Path.home())
+        shortcut.WindowStyle = 1
+        if ico_path.exists():
+            shortcut.IconLocation = str(ico_path)
+        shortcut.Save()
+
+    print(f"✓ Created Start Menu shortcut: {shortcut_path}")
+
+
+def _uninstall_windows() -> None:
+    """Remove the DarSIA Start Menu shortcut from Windows."""
+    appdata = Path(os.environ.get("APPDATA", str(Path.home() / "AppData" / "Roaming")))
+    shortcut_path = appdata / "Microsoft" / "Windows" / "Start Menu" / "Programs" / "DarSIA GUI.lnk"
+
+    if shortcut_path.exists():
+        shortcut_path.unlink()
+        print(f"✓ Removed Start Menu shortcut: {shortcut_path}")
+    else:
+        print("ℹ No Start Menu shortcut found; nothing to uninstall")
+
+
+def main() -> None:
+    """Entry point for the darsia-install-desktop command.
+
+    Installs or uninstalls a desktop application entry for the DarSIA GUI.
+    Dispatches to platform-specific handlers based on sys.platform.
+    """
+    parser = argparse.ArgumentParser(
+        description="Install or uninstall DarSIA GUI desktop/application menu entry.",
+        prog="darsia-install-desktop",
+    )
+    parser.add_argument(
+        "--uninstall",
+        action="store_true",
+        help="Remove the desktop entry instead of installing it.",
+    )
+
+    args = parser.parse_args()
+
+    try:
+        if sys.platform == "linux" or sys.platform.startswith("linux"):
+            if args.uninstall:
+                _uninstall_linux()
+            else:
+                _install_linux()
+        elif sys.platform == "win32":
+            if args.uninstall:
+                _uninstall_windows()
+            else:
+                _install_windows()
+        else:
+            print(f"✗ Unsupported platform: {sys.platform}")
+            sys.exit(1)
+    except FileNotFoundError:
+        print(f"✗ Error: darsia executable not found at {_get_darsia_executable()}")
+        print("  Run 'uv sync' to install the 'darsia' entry point first.")
+        sys.exit(1)
+    except ImportError as e:
+        if "win32com" in str(e):
+            print(f"✗ Error: pywin32 is required on Windows; install it with 'uv sync'")
+            sys.exit(1)
+        raise
+    except Exception as e:
+        print(f"✗ Error: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/darsia/gui/desktop_integration.py
+++ b/src/darsia/gui/desktop_integration.py
@@ -38,7 +38,9 @@ def _get_icon_path() -> Path:
     The icon is at darsia/presets/workflows/interface/DarSIA_Horisontal_Positiv_part.png.
     """
     module_dir = Path(__file__).parent
-    return (module_dir / "../presets/workflows/interface/DarSIA_Horisontal_Positiv_part.png").resolve()
+    return (
+        module_dir / "../presets/workflows/interface/DarSIA_Horisontal_Positiv_part.png"
+    ).resolve()
 
 
 def _ensure_icon_exists() -> bool:
@@ -57,7 +59,9 @@ def _get_icon_cache_dir() -> Path:
     On Linux/macOS: $XDG_CACHE_HOME/darsia or ~/.cache/darsia
     """
     if sys.platform == "win32":
-        localappdata = os.environ.get("LOCALAPPDATA", str(Path.home() / "AppData" / "Local"))
+        localappdata = os.environ.get(
+            "LOCALAPPDATA", str(Path.home() / "AppData" / "Local")
+        )
         return Path(localappdata) / "DarSIA"
     else:
         xdg_cache_home = os.environ.get("XDG_CACHE_HOME", str(Path.home() / ".cache"))
@@ -92,7 +96,9 @@ def _install_linux() -> None:
     """
     from PIL import Image
 
-    xdg_data_home = os.environ.get("XDG_DATA_HOME", str(Path.home() / ".local" / "share"))
+    xdg_data_home = os.environ.get(
+        "XDG_DATA_HOME", str(Path.home() / ".local" / "share")
+    )
     applications_dir = Path(xdg_data_home) / "applications"
     icons_dir = Path(xdg_data_home) / "icons" / "hicolor" / "256x256" / "apps"
 
@@ -128,9 +134,13 @@ Terminal=false
 
 def _uninstall_linux() -> None:
     """Remove the DarSIA .desktop entry and icon from Linux application menu."""
-    xdg_data_home = os.environ.get("XDG_DATA_HOME", str(Path.home() / ".local" / "share"))
+    xdg_data_home = os.environ.get(
+        "XDG_DATA_HOME", str(Path.home() / ".local" / "share")
+    )
     desktop_path = Path(xdg_data_home) / "applications" / "darsia.desktop"
-    icon_path = Path(xdg_data_home) / "icons" / "hicolor" / "256x256" / "apps" / "darsia.png"
+    icon_path = (
+        Path(xdg_data_home) / "icons" / "hicolor" / "256x256" / "apps" / "darsia.png"
+    )
 
     removed = False
     if desktop_path.exists():
@@ -160,7 +170,6 @@ def _install_windows() -> None:
     Requires pywin32; uses only per-user Start Menu (no admin required).
     """
     import win32com.client  # noqa: F401; imported to trigger ImportError if unavailable
-
     from PIL import Image
 
     appdata = Path(os.environ.get("APPDATA", str(Path.home() / "AppData" / "Roaming")))
@@ -199,7 +208,9 @@ def _install_windows() -> None:
 def _uninstall_windows() -> None:
     """Remove the DarSIA Start Menu shortcut and icon cache from Windows."""
     appdata = Path(os.environ.get("APPDATA", str(Path.home() / "AppData" / "Roaming")))
-    shortcut_path = appdata / "Microsoft" / "Windows" / "Start Menu" / "Programs" / "DarSIA GUI.lnk"
+    shortcut_path = (
+        appdata / "Microsoft" / "Windows" / "Start Menu" / "Programs" / "DarSIA GUI.lnk"
+    )
 
     icon_cache_dir = _get_icon_cache_dir()
     ico_path = icon_cache_dir / "darsia.ico"

--- a/src/darsia/gui/desktop_integration.py
+++ b/src/darsia/gui/desktop_integration.py
@@ -50,6 +50,37 @@ def _ensure_icon_exists() -> bool:
     return icon.exists()
 
 
+def _get_icon_cache_dir() -> Path:
+    r"""Get the per-user cache directory for persisting desktop integration icons.
+
+    On Windows: %LOCALAPPDATA%\DarSIA
+    On Linux/macOS: $XDG_CACHE_HOME/darsia or ~/.cache/darsia
+    """
+    if sys.platform == "win32":
+        localappdata = os.environ.get("LOCALAPPDATA", str(Path.home() / "AppData" / "Local"))
+        return Path(localappdata) / "DarSIA"
+    else:
+        xdg_cache_home = os.environ.get("XDG_CACHE_HOME", str(Path.home() / ".cache"))
+        return Path(xdg_cache_home) / "darsia"
+
+
+def _pad_image_to_square(img):
+    """Pad an image to a square canvas, preserving aspect ratio.
+
+    Center the image on a transparent square canvas with dimensions equal to
+    the larger of the image's width or height. Returns a PIL Image object.
+    """
+    from PIL import Image
+
+    width, height = img.size
+    size = max(width, height)
+    square = Image.new("RGBA", (size, size), (0, 0, 0, 0))
+    offset_x = (size - width) // 2
+    offset_y = (size - height) // 2
+    square.paste(img, (offset_x, offset_y), img if img.mode == "RGBA" else None)
+    return square
+
+
 def _install_linux() -> None:
     """Install a .desktop entry for DarSIA in the Linux application menu.
 
@@ -87,7 +118,8 @@ Terminal=false
     if _ensure_icon_exists():
         src_icon = _get_icon_path()
         img = Image.open(src_icon)
-        img_resized = img.resize((256, 256), Image.Resampling.LANCZOS)
+        img_square = _pad_image_to_square(img)
+        img_resized = img_square.resize((256, 256), Image.Resampling.LANCZOS)
         img_resized.save(icon_path)
         print(f"✓ Copied icon: {icon_path}")
     else:
@@ -121,10 +153,12 @@ def _install_windows() -> None:
     Creates %APPDATA%\Microsoft\Windows\Start Menu\Programs\DarSIA GUI.lnk
     pointing to the 'darsia.exe' console script, with a converted .ico icon.
 
+    The icon is persisted at %LOCALAPPDATA%\DarSIA\darsia.ico so the shortcut
+    can reference it persistently (Windows shortcuts store path references,
+    not embedded icon data).
+
     Requires pywin32; uses only per-user Start Menu (no admin required).
     """
-    import tempfile
-
     import win32com.client  # noqa: F401; imported to trigger ImportError if unavailable
 
     from PIL import Image
@@ -133,42 +167,61 @@ def _install_windows() -> None:
     start_menu_dir = appdata / "Microsoft" / "Windows" / "Start Menu" / "Programs"
     start_menu_dir.mkdir(parents=True, exist_ok=True)
 
+    icon_cache_dir = _get_icon_cache_dir()
+    icon_cache_dir.mkdir(parents=True, exist_ok=True)
+    ico_path = icon_cache_dir / "darsia.ico"
+
     darsia_exe = _get_darsia_executable()
     shortcut_path = start_menu_dir / "DarSIA GUI.lnk"
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        ico_path = Path(tmpdir) / "darsia.ico"
+    if _ensure_icon_exists():
+        src_icon = _get_icon_path()
+        img = Image.open(src_icon)
+        img_square = _pad_image_to_square(img)
+        img_resized = img_square.resize((256, 256), Image.Resampling.LANCZOS)
+        img_resized.save(ico_path, "ICO")
+        print(f"✓ Generated icon: {ico_path}")
+    else:
+        print("! Warning: icon file not found; shortcut created without icon")
 
-        if _ensure_icon_exists():
-            src_icon = _get_icon_path()
-            img = Image.open(src_icon)
-            img_resized = img.resize((256, 256), Image.Resampling.LANCZOS)
-            img_resized.save(ico_path, "ICO")
-            print(f"✓ Generated icon: {ico_path}")
-        else:
-            print("! Warning: icon file not found; shortcut created without icon")
-
-        shell = win32com.client.Dispatch("WScript.Shell")  # noqa: F821
-        shortcut = shell.CreateShortcut(str(shortcut_path))
-        shortcut.TargetPath = str(darsia_exe)
-        shortcut.WorkingDirectory = str(Path.home())
-        shortcut.WindowStyle = 1
-        if ico_path.exists():
-            shortcut.IconLocation = str(ico_path)
-        shortcut.Save()
+    shell = win32com.client.Dispatch("WScript.Shell")  # noqa: F821
+    shortcut = shell.CreateShortcut(str(shortcut_path))
+    shortcut.TargetPath = str(darsia_exe)
+    shortcut.WorkingDirectory = str(Path.home())
+    shortcut.WindowStyle = 1
+    if ico_path.exists():
+        shortcut.IconLocation = str(ico_path)
+    shortcut.Save()
 
     print(f"✓ Created Start Menu shortcut: {shortcut_path}")
 
 
 def _uninstall_windows() -> None:
-    """Remove the DarSIA Start Menu shortcut from Windows."""
+    """Remove the DarSIA Start Menu shortcut and icon cache from Windows."""
     appdata = Path(os.environ.get("APPDATA", str(Path.home() / "AppData" / "Roaming")))
     shortcut_path = appdata / "Microsoft" / "Windows" / "Start Menu" / "Programs" / "DarSIA GUI.lnk"
 
+    icon_cache_dir = _get_icon_cache_dir()
+    ico_path = icon_cache_dir / "darsia.ico"
+
+    removed = False
     if shortcut_path.exists():
         shortcut_path.unlink()
         print(f"✓ Removed Start Menu shortcut: {shortcut_path}")
-    else:
+        removed = True
+
+    if ico_path.exists():
+        ico_path.unlink()
+        print(f"✓ Removed icon cache: {ico_path}")
+        removed = True
+
+    if icon_cache_dir.exists():
+        try:
+            icon_cache_dir.rmdir()
+        except OSError:
+            pass
+
+    if not removed:
         print("ℹ No Start Menu shortcut found; nothing to uninstall")
 
 

--- a/tests/unit/gui/test_desktop_integration.py
+++ b/tests/unit/gui/test_desktop_integration.py
@@ -79,6 +79,19 @@ class TestLinuxDesktopIntegration:
         assert "Icon=darsia" in content
 
     @pytest.mark.skipif(sys.platform == "win32", reason="Linux-only test")
+    def test_install_linux_creates_icon_file(self, tmp_path, monkeypatch, capsys):
+        """Test that _install_linux creates a persistent icon file that survives function return."""
+        from darsia.gui.desktop_integration import _install_linux
+
+        xdg_data = tmp_path / "data"
+        monkeypatch.setenv("XDG_DATA_HOME", str(xdg_data))
+
+        _install_linux()
+
+        icon_path = xdg_data / "icons" / "hicolor" / "256x256" / "apps" / "darsia.png"
+        assert icon_path.exists(), "Icon file should be created and persist after _install_linux returns"
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Linux-only test")
     def test_uninstall_linux_removes_desktop_file(self, tmp_path, monkeypatch, capsys):
         """Test that _uninstall_linux removes a previously-installed .desktop file."""
         from darsia.gui.desktop_integration import _install_linux, _uninstall_linux
@@ -132,17 +145,55 @@ class TestWindowsDesktopIntegration:
         assert callable(_install_windows), "_install_windows should be callable"
 
     @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only test")
-    def test_uninstall_windows_no_error_if_nothing_installed(self, tmp_path, monkeypatch, capsys):
-        """Test that _uninstall_windows gracefully handles missing shortcut."""
+    def test_install_windows_creates_persistent_ico(self, tmp_path, monkeypatch):
+        """Test that _install_windows creates an .ico file that persists after function returns.
+
+        This is the critical test that would catch the bug where the icon was stored in
+        a TemporaryDirectory and deleted when the function exited, leaving the .lnk
+        shortcut pointing at a nonexistent file.
+        """
+        from darsia.gui.desktop_integration import _install_windows
+
+        appdata = tmp_path / "AppData" / "Roaming"
+        localappdata = tmp_path / "AppData" / "Local"
+        monkeypatch.setenv("APPDATA", str(appdata))
+        monkeypatch.setenv("LOCALAPPDATA", str(localappdata))
+
+        _install_windows()
+
+        ico_path = localappdata / "DarSIA" / "darsia.ico"
+        assert ico_path.exists(), "Icon file should be persisted and exist after _install_windows returns"
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only test")
+    def test_uninstall_windows_removes_persistent_ico(self, tmp_path, monkeypatch):
+        """Test that _uninstall_windows removes the persisted icon file."""
+        from darsia.gui.desktop_integration import _install_windows, _uninstall_windows
+
+        appdata = tmp_path / "AppData" / "Roaming"
+        localappdata = tmp_path / "AppData" / "Local"
+        monkeypatch.setenv("APPDATA", str(appdata))
+        monkeypatch.setenv("LOCALAPPDATA", str(localappdata))
+
+        _install_windows()
+        ico_path = localappdata / "DarSIA" / "darsia.ico"
+        assert ico_path.exists(), "Icon should exist after install"
+
+        _uninstall_windows()
+        assert not ico_path.exists(), "Icon should be removed after uninstall"
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only test")
+    def test_uninstall_windows_no_error_if_nothing_installed(self, tmp_path, monkeypatch):
+        """Test that _uninstall_windows gracefully handles missing shortcut and icon."""
         from darsia.gui.desktop_integration import _uninstall_windows
 
         appdata = tmp_path / "AppData" / "Roaming"
+        localappdata = tmp_path / "AppData" / "Local"
         monkeypatch.setenv("APPDATA", str(appdata))
+        monkeypatch.setenv("LOCALAPPDATA", str(localappdata))
 
         _uninstall_windows()
 
-        captured = capsys.readouterr()
-        assert "nothing to uninstall" in captured.out.lower()
+        # Should complete without error even when nothing is installed
 
 
 class TestMainDispatch:

--- a/tests/unit/gui/test_desktop_integration.py
+++ b/tests/unit/gui/test_desktop_integration.py
@@ -1,0 +1,209 @@
+"""Test desktop integration module: path resolution, file operations, and uninstall logic.
+
+These tests use tmp_path and monkeypatching to avoid real filesystem/registry writes
+in CI environments. Platform-specific logic is tested separately for Linux and Windows.
+"""
+
+import sys
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+
+
+class TestIconResolution:
+    """Test icon file discovery."""
+
+    def test_get_icon_path_returns_pathlib_path(self):
+        """Test that _get_icon_path returns a Path object."""
+        from darsia.gui.desktop_integration import _get_icon_path
+
+        icon = _get_icon_path()
+        assert isinstance(icon, Path)
+
+    def test_icon_file_exists(self):
+        """Test that the icon file exists in the installed package."""
+        from darsia.gui.desktop_integration import _ensure_icon_exists
+
+        assert _ensure_icon_exists(), "DarSIA logo PNG should exist in the package"
+
+
+class TestExecutableResolution:
+    """Test resolution of the darsia console script."""
+
+    def test_get_darsia_executable_returns_path(self):
+        """Test that _get_darsia_executable returns a Path object."""
+        from darsia.gui.desktop_integration import _get_darsia_executable
+
+        exe = _get_darsia_executable()
+        assert isinstance(exe, Path)
+
+    def test_darsia_executable_in_bin_directory(self):
+        """Test that the resolved executable is in the same bin/Scripts directory as sys.executable."""
+        from darsia.gui.desktop_integration import _get_darsia_executable
+
+        exe = _get_darsia_executable()
+        sys_bin = Path(sys.executable).parent
+        assert exe.parent == sys_bin, "darsia exe should be in the same bin directory as sys.executable"
+
+    def test_darsia_executable_name_by_platform(self):
+        """Test that the executable name matches the platform."""
+        from darsia.gui.desktop_integration import _get_darsia_executable
+
+        exe = _get_darsia_executable()
+        if sys.platform == "win32":
+            assert exe.name == "darsia.exe", "Windows should resolve to darsia.exe"
+        else:
+            assert exe.name == "darsia", "Unix should resolve to darsia (no extension)"
+
+
+class TestLinuxDesktopIntegration:
+    """Test Linux .desktop file installation/uninstall."""
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Linux-only test")
+    def test_install_linux_creates_desktop_file(self, tmp_path, monkeypatch, capsys):
+        """Test that _install_linux creates a .desktop file in the mocked XDG_DATA_HOME."""
+        from darsia.gui.desktop_integration import _install_linux
+
+        xdg_data = tmp_path / "data"
+        monkeypatch.setenv("XDG_DATA_HOME", str(xdg_data))
+
+        _install_linux()
+
+        desktop_path = xdg_data / "applications" / "darsia.desktop"
+        assert desktop_path.exists(), ".desktop file should be created"
+
+        content = desktop_path.read_text()
+        assert "[Desktop Entry]" in content
+        assert "Type=Application" in content
+        assert "Name=DarSIA GUI" in content
+        assert "Icon=darsia" in content
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Linux-only test")
+    def test_uninstall_linux_removes_desktop_file(self, tmp_path, monkeypatch, capsys):
+        """Test that _uninstall_linux removes a previously-installed .desktop file."""
+        from darsia.gui.desktop_integration import _install_linux, _uninstall_linux
+
+        xdg_data = tmp_path / "data"
+        monkeypatch.setenv("XDG_DATA_HOME", str(xdg_data))
+
+        _install_linux()
+        desktop_path = xdg_data / "applications" / "darsia.desktop"
+        assert desktop_path.exists()
+
+        _uninstall_linux()
+        assert not desktop_path.exists(), ".desktop file should be removed after uninstall"
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Linux-only test")
+    def test_uninstall_linux_no_error_if_nothing_installed(self, tmp_path, monkeypatch, capsys):
+        """Test that _uninstall_linux gracefully handles missing .desktop file."""
+        from darsia.gui.desktop_integration import _uninstall_linux
+
+        xdg_data = tmp_path / "data"
+        monkeypatch.setenv("XDG_DATA_HOME", str(xdg_data))
+
+        _uninstall_linux()
+
+        captured = capsys.readouterr()
+        assert "nothing to uninstall" in captured.out.lower()
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Linux-only test")
+    def test_install_linux_xdg_data_home_default(self, tmp_path, monkeypatch, capsys):
+        """Test that _install_linux uses ~/.local/share as default XDG_DATA_HOME."""
+        from darsia.gui.desktop_integration import _install_linux
+
+        home = tmp_path / "home"
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+
+        _install_linux()
+
+        desktop_path = home / ".local" / "share" / "applications" / "darsia.desktop"
+        assert desktop_path.exists(), ".desktop file should use ~/.local/share as default"
+
+
+class TestWindowsDesktopIntegration:
+    """Test Windows Start Menu shortcut installation/uninstall."""
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only test")
+    def test_install_windows_exists_when_platform_is_win32(self):
+        """Test that _install_windows exists and is callable on Windows."""
+        from darsia.gui.desktop_integration import _install_windows
+
+        assert callable(_install_windows), "_install_windows should be callable"
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only test")
+    def test_uninstall_windows_no_error_if_nothing_installed(self, tmp_path, monkeypatch, capsys):
+        """Test that _uninstall_windows gracefully handles missing shortcut."""
+        from darsia.gui.desktop_integration import _uninstall_windows
+
+        appdata = tmp_path / "AppData" / "Roaming"
+        monkeypatch.setenv("APPDATA", str(appdata))
+
+        _uninstall_windows()
+
+        captured = capsys.readouterr()
+        assert "nothing to uninstall" in captured.out.lower()
+
+
+class TestMainDispatch:
+    """Test the main() dispatcher function."""
+
+    def test_main_install_calls_platform_handler(self):
+        """Test that main() calls the correct platform-specific install handler."""
+        from darsia.gui.desktop_integration import main
+
+        install_called = {}
+
+        def mock_install_linux():
+            install_called["linux"] = True
+
+        def mock_install_windows():
+            install_called["windows"] = True
+
+        with patch("darsia.gui.desktop_integration._install_linux", mock_install_linux):
+            with patch("darsia.gui.desktop_integration._install_windows", mock_install_windows):
+                with patch("sys.platform", "linux"):
+                    with patch("sys.argv", ["darsia-install-desktop"]):
+                        main()
+                        assert install_called.get("linux"), "Linux install handler should be called"
+
+    def test_main_uninstall_calls_platform_handler(self):
+        """Test that main() --uninstall calls the correct platform-specific uninstall handler."""
+        from darsia.gui.desktop_integration import main
+
+        uninstall_called = {}
+
+        def mock_uninstall_linux():
+            uninstall_called["linux"] = True
+
+        def mock_uninstall_windows():
+            uninstall_called["windows"] = True
+
+        with patch("darsia.gui.desktop_integration._uninstall_linux", mock_uninstall_linux):
+            with patch("darsia.gui.desktop_integration._uninstall_windows", mock_uninstall_windows):
+                with patch("sys.platform", "linux"):
+                    with patch("sys.argv", ["darsia-install-desktop", "--uninstall"]):
+                        main()
+                        assert uninstall_called.get("linux"), "Linux uninstall handler should be called"
+
+    def test_main_unsupported_platform_exits(self):
+        """Test that main() exits with an error on unsupported platforms."""
+        from darsia.gui.desktop_integration import main
+
+        with patch("sys.platform", "darwin"):
+            with patch("sys.argv", ["darsia-install-desktop"]):
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+                assert exc_info.value.code == 1
+
+    def test_main_missing_executable_exits(self):
+        """Test that main() exits if the darsia executable is not found."""
+        from darsia.gui.desktop_integration import main
+
+        with patch("darsia.gui.desktop_integration._get_darsia_executable", return_value=Path("/nonexistent/darsia")):
+            with patch("darsia.gui.desktop_integration._install_linux", side_effect=FileNotFoundError("darsia not found")):
+                with patch("sys.platform", "linux"):
+                    with patch("sys.argv", ["darsia-install-desktop"]):
+                        with pytest.raises(SystemExit) as exc_info:
+                            main()
+                        assert exc_info.value.code == 1

--- a/tests/unit/gui/test_main_entrypoint.py
+++ b/tests/unit/gui/test_main_entrypoint.py
@@ -1,0 +1,40 @@
+"""Test that the main() entry point for darsia CLI launcher is callable and correct.
+
+This test verifies that the darsia.gui.__main__.main() function is properly defined
+as an entry point. Qt application tests are covered by existing test_main_window_startup.py
+which uses qtbot fixtures.
+"""
+
+import inspect
+
+
+def test_main_function_exists():
+    """Test that the main() function exists and is callable."""
+    from darsia.gui.__main__ import main
+
+    assert callable(main), "main() function should be callable"
+
+
+def test_main_function_signature():
+    """Test that main() has the correct signature (no required args, returns None)."""
+    from darsia.gui.__main__ import main
+
+    sig = inspect.signature(main)
+    assert len(sig.parameters) == 0, "main() should not require any arguments"
+    assert sig.return_annotation in (None, "None", type(None)), "main() should return None"
+
+
+def test_main_function_has_docstring():
+    """Test that main() has a docstring."""
+    from darsia.gui.__main__ import main
+
+    assert main.__doc__ is not None, "main() should have a docstring"
+    assert "GUI" in main.__doc__ or "application" in main.__doc__, "Docstring should describe the GUI"
+
+
+def test_main_is_importable():
+    """Test that darsia.gui.__main__:main is a valid entry point reference."""
+    from darsia.gui import __main__
+
+    assert hasattr(__main__, "main"), "darsia.gui.__main__ should have a 'main' attribute"
+    assert callable(getattr(__main__, "main")), "main should be callable"


### PR DESCRIPTION
This pull request introduces a desktop integration feature for the DarSIA GUI, making it easier for users to launch the application from their operating system's application menu or Start Menu. It adds platform-specific installation and uninstallation scripts, updates packaging and entry points, and includes comprehensive tests for the new functionality. The documentation is also updated to reflect these changes.

**Desktop Integration Feature:**

* Added a new module `desktop_integration.py` that provides commands to install or uninstall DarSIA GUI menu entries for Linux (via `.desktop` files) and Windows (via Start Menu shortcuts), including icon handling and platform-specific logic.
* Updated `pyproject.toml` to register new entry points: `darsia` as a GUI script for launching the app, and `darsia-install-desktop` as a script for desktop integration. Also added `pywin32` as a Windows-only dependency.

**GUI Entrypoint Improvements:**

* Refactored `src/darsia/gui/__main__.py` to provide a `main()` function as the unified entry point for both `python -m darsia.gui` and the new `darsia` command, with improved documentation. [[1]](diffhunk://#diff-c76fbe4c90cfbcb10e7445c6112ae841a0fac40fde4dcc71f1ff1756022fa62bL17-R36) [[2]](diffhunk://#diff-c76fbe4c90cfbcb10e7445c6112ae841a0fac40fde4dcc71f1ff1756022fa62bR7-R8)

**Documentation Updates:**

* Updated `README.md` to document the new GUI launch commands and desktop integration feature, including installation and uninstallation instructions for both Linux and Windows.

**Testing:**

* Added `test_desktop_integration.py` to thoroughly test path resolution, file operations, and platform-specific logic for the desktop integration module, using pytest and monkeypatching to avoid real system changes.
* Added `test_main_entrypoint.py` to verify that the new `main()` entry point for the GUI is correctly defined, importable, and documented.