### PR TITLE
Setting selection

### DIFF
--- a/src/darsia/gui/ui/main_window.py
+++ b/src/darsia/gui/ui/main_window.py
@@ -198,6 +198,11 @@ class MainWindow(QMainWindow):
         self.selected_checkbox_id = checkbox_id
         self.settings_factory.display_settings(action, [checkbox_id])
 
+    def _on_open_full_config(self):
+        """Handle opening full config: deselect sidebar and show all settings."""
+        self.sidebar.deselect_all()
+        self.settings_factory.display_full_settings()
+
     def toggle_logging(self, visible: bool):
         """Show or hide the logging panel (View > Show Logging / Ctrl+L)."""
         self.log_scroll_area.setVisible(visible)

--- a/src/darsia/gui/ui/menu.py
+++ b/src/darsia/gui/ui/menu.py
@@ -57,7 +57,7 @@ class MenuBuilder:
         self.open_full_config_action = self._add_action(
             settings_menu,
             "Open &Full Config",
-            self.main_window.settings_factory.display_full_settings,
+            self.main_window._on_open_full_config,
             "Ctrl+E",
         )
 

--- a/src/darsia/gui/ui/settings.py
+++ b/src/darsia/gui/ui/settings.py
@@ -281,10 +281,13 @@ class SettingsFactory:
                         "rows": field_or_result["rows"],
                     }
                 elif "dataclass_group_map" in field_or_result:
-                    self.main_window.settings_inputs[setting["key"]] = {
+                    entry = {
                         "dataclass_group_map": True,
                         "entries": field_or_result["entries"],
                     }
+                    if "array_key" in field_or_result:
+                        entry["array_key"] = field_or_result["array_key"]
+                    self.main_window.settings_inputs[setting["key"]] = entry
                 elif "registry_key_list" in field_or_result:
                     self.main_window.settings_inputs[setting["key"]] = {
                         "registry_key_list": True,
@@ -748,11 +751,14 @@ class SettingsFactory:
                 import traceback
 
                 self.main_window.print_log(traceback.format_exc())
-                return display_name, {
+                fallback = {
                     "widget": header_widget,
                     "dataclass_group_map": True,
                     "entries": entries_data,
                 }
+                if array_key:
+                    fallback["array_key"] = array_key
+                return display_name, fallback
 
         else:
             return display_name, {"dataclass_group_map": True, "entries": []}

--- a/src/darsia/gui/ui/sidebar.py
+++ b/src/darsia/gui/ui/sidebar.py
@@ -371,3 +371,13 @@ class Sidebar(QWidget):
         if self._selected_action and self._selected_checkbox_id:
             return (self._selected_action, self._selected_checkbox_id)
         return None
+
+    def deselect_all(self):
+        """Visually deselect all rows and clear selection state."""
+        if self._selected_row is not None:
+            self._selected_row.set_selected(False)
+        for section in self._sections.values():
+            section.deselect_all()
+        self._selected_row = None
+        self._selected_action = None
+        self._selected_checkbox_id = None


### PR DESCRIPTION
This pull request introduces improvements to the settings UI, particularly in how the application handles displaying the full configuration and managing selection state in the sidebar. Additionally, it enhances the handling of grouped dataclass settings, ensuring that extra metadata is preserved in edge cases.

**Settings UI improvements:**

* Added a new method `_on_open_full_config` in `main_window.py` to handle the "Open Full Config" action by deselecting all sidebar items and displaying all settings. The menu action now calls this new method instead of directly displaying the settings. [[1]](diffhunk://#diff-1d5e429d3a96abcb90ca617dd45a0d8b00c90f2039e410299287ddc93261cfd3R201-R205) [[2]](diffhunk://#diff-b0ced1c428cb35f2fe1ed450be8395e566fd85e8b8fcd10af0b57bcb6914c787L60-R60)
* Implemented a `deselect_all` method in the `Sidebar` class to clear all selection state and visually deselect rows, supporting the new full config behavior.

**Dataclass group settings handling:**

* Updated the logic in `settings.py` to ensure that when building tab forms or handling error fallbacks, any `array_key` present in `dataclass_group_map` entries is preserved and included in the settings input data structure. This prevents loss of important metadata in grouped settings scenarios. [[1]](diffhunk://#diff-6269baaad21d2a42b272d2c2438703ae4c8206c44f7ec96db24fa041aceec5fdL284-R290) [[2]](diffhunk://#diff-6269baaad21d2a42b272d2c2438703ae4c8206c44f7ec96db24fa041aceec5fdL751-R761)