### PR TITLE
MAINT: Add ctrl shortcuts

### DIFF
--- a/src/darsia/gui/ui/config_controller.py
+++ b/src/darsia/gui/ui/config_controller.py
@@ -35,6 +35,8 @@ class ConfigController:
         self.main_window.config_dict = {}
         add_recent_config(file)
         self.main_window.print_log(f"New config created and opened: {file}")
+        self.main_window.sidebar.deselect_all()
+        self.main_window.settings_factory.display_full_settings()
 
     def open_config(self):
         """Open a config file via dialog and load it immediately."""
@@ -89,3 +91,5 @@ class ConfigController:
         self.main_window.config_file = file
         add_recent_config(file)
         self.main_window.print_log(f"Config loaded: {file}")
+        self.main_window.sidebar.deselect_all()
+        self.main_window.settings_factory.display_full_settings()

--- a/src/darsia/gui/ui/main_window.py
+++ b/src/darsia/gui/ui/main_window.py
@@ -203,6 +203,26 @@ class MainWindow(QMainWindow):
         self.sidebar.deselect_all()
         self.settings_factory.display_full_settings()
 
+    def run_selected_workflow(self):
+        """Run the currently selected sidebar workflow (Play button / Ctrl+Return)."""
+        if self.selected_action is None:
+            self.print_log("Select an item in the sidebar first.")
+            return
+
+        tab_manager = self.action_dispatch.get(self.selected_action)
+        if tab_manager:
+            tab_manager.on_run_clicked()
+
+    def abort_selected_workflow(self):
+        """Abort the currently running workflow (Stop button / Ctrl+Escape)."""
+        if self.selected_action is None:
+            self.print_log("No workflow running.")
+            return
+
+        tab_manager = self.action_dispatch.get(self.selected_action)
+        if tab_manager:
+            tab_manager.on_abort_clicked()
+
     def toggle_logging(self, visible: bool):
         """Show or hide the logging panel (View > Show Logging / Ctrl+L)."""
         self.log_scroll_area.setVisible(visible)

--- a/src/darsia/gui/ui/menu.py
+++ b/src/darsia/gui/ui/menu.py
@@ -61,6 +61,24 @@ class MenuBuilder:
             "Ctrl+E",
         )
 
+        run_menu = menu_bar.addMenu("&Run")
+        self.play_action = self._add_action(
+            run_menu,
+            "&Run Selected Workflow",
+            self.main_window.run_selected_workflow,
+        )
+        # Cover both the main-keyboard Enter/Return key and the numpad Enter key.
+        self.play_action.setShortcuts(
+            [QKeySequence("Ctrl+Return"), QKeySequence("Ctrl+Enter")]
+        )
+        self.stop_action = self._add_action(
+            run_menu,
+            "&Stop Workflow",
+            self.main_window.abort_selected_workflow,
+            "Ctrl+Escape",
+        )
+        self.stop_action.setEnabled(False)
+
         view_menu = menu_bar.addMenu("&View")
         theme_menu = view_menu.addMenu("Switch &Theme")
         theme_group = QActionGroup(self.main_window)

--- a/src/darsia/gui/ui/toolbar.py
+++ b/src/darsia/gui/ui/toolbar.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 
 from PySide6.QtCore import Qt
-from PySide6.QtGui import QAction, QIcon
+from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import QStyle
 
 from .icons import themed_icon
@@ -58,18 +58,16 @@ class ToolbarBuilder:
         toolbar.addAction(self.menu_builder.save_action)
         toolbar.addAction(self.menu_builder.open_full_config_action)
 
-        # Add separator and Play/Stop actions for workflow control
+        # Add separator and Play/Stop actions for workflow control (created by
+        # MenuBuilder so they also appear, with shortcuts, in the Run menu).
         toolbar.addSeparator()
 
-        self.play_action = QAction("Play")
-        self.play_action.triggered.connect(self._on_play)
-        self._configure(self.play_action, "play", "Run Selected Workflow")
+        self.play_action = self.menu_builder.play_action
+        self._configure(self.play_action, "play", "Run Selected Workflow (Ctrl+Return)")
         toolbar.addAction(self.play_action)
 
-        self.stop_action = QAction("Stop")
-        self.stop_action.triggered.connect(self._on_stop)
-        self.stop_action.setEnabled(False)
-        self._configure(self.stop_action, "stop", "Stop Workflow")
+        self.stop_action = self.menu_builder.stop_action
+        self._configure(self.stop_action, "stop", "Stop Workflow (Ctrl+Escape)")
         toolbar.addAction(self.stop_action)
 
         theme_signal.theme_changed.connect(self.refresh_icons)
@@ -84,30 +82,6 @@ class ToolbarBuilder:
         """Rebuild all qtawesome-backed icons from current palette."""
         for key, action in self._themed_actions.items():
             action.setIcon(self._load_icon(key))
-
-    def _on_play(self):
-        """Handle Play button: dispatch to selected workflow."""
-        if self.main_window.selected_action is None:
-            self.main_window.print_log("Select an item in the sidebar first.")
-            return
-
-        tab_manager = self.main_window.action_dispatch.get(
-            self.main_window.selected_action
-        )
-        if tab_manager:
-            tab_manager.on_run_clicked()
-
-    def _on_stop(self):
-        """Handle Stop button: abort selected workflow."""
-        if self.main_window.selected_action is None:
-            self.main_window.print_log("No workflow running.")
-            return
-
-        tab_manager = self.main_window.action_dispatch.get(
-            self.main_window.selected_action
-        )
-        if tab_manager:
-            tab_manager.on_abort_clicked()
 
     def _load_icon(self, key):
         custom_path = _ICON_DIR / f"{key}.png"


### PR DESCRIPTION
This pull request introduces a new workflow control feature to the GUI, allowing users to run or stop the currently selected workflow via a dedicated "Run" menu and toolbar buttons, both with keyboard shortcuts. It also refactors related code to centralize workflow control logic and ensures consistent sidebar and settings state when creating or loading configs.

Workflow control feature:

* Added a new "Run" menu with "Run Selected Workflow" and "Stop Workflow" actions, both accessible via toolbar buttons and keyboard shortcuts (Ctrl+Return and Ctrl+Escape). The actions are created in `menu.py` and reused in the toolbar for consistency. [[1]](diffhunk://#diff-b0ced1c428cb35f2fe1ed450be8395e566fd85e8b8fcd10af0b57bcb6914c787R64-R81) [[2]](diffhunk://#diff-d516ee851adccc1250963cf4cdc59ae44a66d74ba041799161a856fcc3e4819bL61-R70)
* Implemented `run_selected_workflow` and `abort_selected_workflow` methods in `main_window.py` to handle running and aborting workflows, centralizing the workflow control logic.
* Removed redundant workflow control logic from `toolbar.py`, delegating all workflow actions to the main window.

Config and UI consistency:

* Ensured that creating or loading a config always deselects all sidebar items and displays the full settings panel, keeping the UI state consistent. [[1]](diffhunk://#diff-d33b9a4017eb10d46262fc8398c61a871d0b8f9d0c70c6735d78644bfa850f62R38-R39) [[2]](diffhunk://#diff-d33b9a4017eb10d46262fc8398c61a871d0b8f9d0c70c6735d78644bfa850f62R94-R95)

Minor cleanup:

* Removed an unused import (`QAction`) from `toolbar.py`.