### PR TITLE
Make remove button always visible

### DIFF
--- a/src/darsia/gui/ui/settings.py
+++ b/src/darsia/gui/ui/settings.py
@@ -726,9 +726,8 @@ class SettingsFactory:
                 refresh_remove_buttons()
 
             def refresh_remove_buttons():
-                show_remove = len(entries_data) > 1
                 for entry in entries_data:
-                    entry["remove_button"].setVisible(show_remove)
+                    entry["remove_button"].setVisible(True)
 
             try:
                 # Connect add button
@@ -816,9 +815,8 @@ class SettingsFactory:
         row_combos = []  # List of QComboBox widgets for save_settings
 
         def refresh_remove_buttons():
-            show_remove = len(row_data_list) > 1
             for row_data in row_data_list:
-                row_data["remove_button"].setVisible(show_remove)
+                row_data["remove_button"].setVisible(True)
 
         add_button = QPushButton("Add key")
 
@@ -965,9 +963,8 @@ class SettingsFactory:
         row_combos = []
 
         def refresh_remove_buttons():
-            show_remove = len(row_data_list) > 1
             for row_data in row_data_list:
-                row_data["remove_button"].setVisible(show_remove)
+                row_data["remove_button"].setVisible(True)
 
         add_button = QPushButton("Add format")
 
@@ -1106,9 +1103,8 @@ class SettingsFactory:
         row_combos = []
 
         def refresh_remove_buttons():
-            show_remove = len(row_data_list) > 1
             for row_data in row_data_list:
-                row_data["remove_button"].setVisible(show_remove)
+                row_data["remove_button"].setVisible(True)
 
         add_button = QPushButton("Add ROI")
 
@@ -1246,9 +1242,8 @@ class SettingsFactory:
         row_combos = []
 
         def refresh_remove_buttons():
-            show_remove = len(row_data_list) > 1
             for row_data in row_data_list:
-                row_data["remove_button"].setVisible(show_remove)
+                row_data["remove_button"].setVisible(True)
 
         add_button = QPushButton("Add Color")
 
@@ -1602,9 +1597,8 @@ class SettingsFactory:
         row_data_list = []  # Track row data (widget, remove_button)
 
         def refresh_remove_buttons():
-            show_remove = len(row_data_list) > 1
             for row in row_data_list:
-                row["remove_button"].setVisible(show_remove)
+                row["remove_button"].setVisible(True)
 
         add_button = QPushButton("Add group")
 
@@ -1797,9 +1791,8 @@ class SettingsFactory:
         row_data_list = []  # Track row data (widget, remove_button)
 
         def refresh_remove_buttons():
-            show_remove = len(row_data_list) > 1
             for row in row_data_list:
-                row["remove_button"].setVisible(show_remove)
+                row["remove_button"].setVisible(True)
 
         add_button = QPushButton("Add row")
 


### PR DESCRIPTION
This pull request updates the logic for displaying "remove" buttons in several list input sections of the settings GUI. Previously, the "remove" button was only visible when there was more than one entry; now, the "remove" button is always visible for each entry, regardless of the number of entries.

UI behavior changes for list inputs in `settings.py`:

* Always show the "remove" button for each entry in the following list input sections, instead of hiding it when only one entry exists:
  - General entries (`remove()` function)
  - Name extraction (`extract_names` function)
  - Format key list (`create_format_key_list_input`)
  - ROI key list (`create_roi_key_list_input`)
  - Color key list (`create_color_key_list_input`)
  - Integer group list (`create_int_group_list_input`)
  - Integer list map (`create_int_list_map_input`)