### PR TITLE
Clean up dataclass groups

### DIFF
--- a/src/darsia/gui/ui/settings.py
+++ b/src/darsia/gui/ui/settings.py
@@ -585,6 +585,9 @@ class SettingsFactory:
                         -1
                     ]  # Unqualified name
 
+                    if field_name == "name":
+                        continue
+
                     # Use create_setting_edit for all other fields (returns composite
                     # wrapper or group result)
                     label_text, field_widget = self.create_setting_edit(field_schema)

--- a/src/darsia/gui/ui/settings.py
+++ b/src/darsia/gui/ui/settings.py
@@ -2550,6 +2550,13 @@ class SettingsFactory:
         # Create a tabbed interface with one tab per section
         tabs = QTabWidget()
 
+        section_titles = {
+            "registry": "Data registry",
+            "format_registry": "Format registry",
+            "roi": "Roi registry",
+            "color": "Color registry",
+        }
+
         # Iterate through sections in order (dict preserves insertion order in Python 3.7+)
         for section, settings_list in settings_by_section.items():
             # Create a scroll area and container for this section's fields
@@ -2568,8 +2575,9 @@ class SettingsFactory:
             # Push content to top by adding a stretch row at the end
             tab_form.addItem(QVBoxLayout())
 
-            # Add this section as a tab (capitalize section name for display)
-            tabs.addTab(tab_container, section.capitalize())
+            # Add this section as a tab using the section_titles map
+            tab_title = section_titles.get(section, section.capitalize())
+            tabs.addTab(tab_container, tab_title)
 
         self.main_window.settings_layout.addWidget(tabs)
         self.main_window.settings_layout.addStretch()

--- a/src/darsia/presets/workflows/config/color_embedding_registry.py
+++ b/src/darsia/presets/workflows/config/color_embedding_registry.py
@@ -482,6 +482,7 @@ class ColorPathEmbeddingConfig:
         metadata={
             "name": "Calibration Folder",
             "help": "Optional override for the calibration output folder.",
+            "hidden": True,
         },
     )
 
@@ -542,6 +543,7 @@ class ColorRangeEmbeddingConfig:
         metadata={
             "name": "Calibration Folder",
             "help": "Optional override for the calibration output folder.",
+            "hidden": True,
         },
     )
 
@@ -595,6 +597,7 @@ class ColorChannelEmbeddingConfig:
         metadata={
             "name": "Calibration Folder",
             "help": "Optional override for the calibration output folder.",
+            "hidden": True,
         },
     )
 


### PR DESCRIPTION
This pull request introduces improvements to the settings UI and configuration handling for color embedding workflows. The most important changes are grouped below:

**User Interface Improvements:**

* Added a `section_titles` mapping in `settings.py` to provide more user-friendly tab titles for settings sections, replacing raw section names with descriptive labels like "Data registry" and "Color registry". Tabs now use these titles when available. [[1]](diffhunk://#diff-6269baaad21d2a42b272d2c2438703ae4c8206c44f7ec96db24fa041aceec5fdR2553-R2559) [[2]](diffhunk://#diff-6269baaad21d2a42b272d2c2438703ae4c8206c44f7ec96db24fa041aceec5fdL2568-R2580)
* Updated the settings group title logic to skip rendering the "name" field, preventing unnecessary UI elements for this special field.

**Configuration Enhancements:**

* Marked the "Calibration Folder" field as hidden in the metadata for `ColorPathEmbeddingConfig`, `ColorRangeEmbeddingConfig`, and `ColorChannelEmbeddingConfig`, ensuring it does not appear in the UI unless explicitly needed. [[1]](diffhunk://#diff-cb241b325b4988e508d68dcca7253c39b8ae090f8af976b06b095f544307d57aR485) [[2]](diffhunk://#diff-cb241b325b4988e508d68dcca7253c39b8ae090f8af976b06b095f544307d57aR546) [[3]](diffhunk://#diff-cb241b325b4988e508d68dcca7253c39b8ae090f8af976b06b095f544307d57aR600)