### PR TITLE
Parse lists

### DIFF
--- a/src/darsia/gui/ui/schema/dataclass_introspection.py
+++ b/src/darsia/gui/ui/schema/dataclass_introspection.py
@@ -189,6 +189,23 @@ def _infer_list_type(field_type: Any) -> str:
     return _infer_widget_type(inner, {})
 
 
+def _infer_fixed_length(field_type: Any) -> int | None:
+    """Infer the fixed arity of a tuple[...] annotation, else None.
+
+    Args:
+        field_type: The type annotation (e.g., tuple[int, int], tuple[float, float, float]).
+
+    Returns:
+        The number of elements if fixed-arity tuple, else None.
+    """
+    if get_origin(field_type) is not tuple:
+        return None
+    args = get_args(field_type)
+    if not args or any(a is Ellipsis for a in args):
+        return None  # bare tuple, or variable-length tuple[X, ...]
+    return len(args)
+
+
 def _build_fields(dataclass_type: type, key_prefix: str) -> list[dict[str, Any]]:
     """Build field schema for a dataclass type, recursing into Optional[dataclass] fields.
 
@@ -262,9 +279,11 @@ def _build_fields(dataclass_type: type, key_prefix: str) -> list[dict[str, Any]]
                 "auto_add_empty": field.metadata.get("auto_add_empty", None),
             }
 
-            # For list/tuple types, add the element type label
+            # For list/tuple types, add the element type label and infer fixed_length
             if widget_type == "list":
-                setting_dict["list_type"] = _infer_list_type(field_type)
+                setting_dict["list_type"] = _infer_list_type(inner_type)
+                # Infer fixed_length from tuple[X, ...] arity (the type is the source of truth)
+                setting_dict["fixed_length"] = _infer_fixed_length(inner_type)
             elif widget_type == "dataclass_group_map":
                 # Infer entry_dataclass from dict[str, X] type annotation
                 args = get_args(field_type)

--- a/src/darsia/gui/ui/settings.py
+++ b/src/darsia/gui/ui/settings.py
@@ -38,6 +38,82 @@ def unwrap_composite_widget(value):
     return value
 
 
+def _parse_list_text(text, list_type=None):
+    """Parse user-friendly list text (space/comma-separated or bracket syntax)
+    into a Python list.
+
+    Accepts multiple input formats:
+    - Python literal: [1, 2, 3] or (1, 2, 3) or 1, 2, 3
+    - Space-separated: 1 2 3
+    - Comma-separated: 1, 2, 3
+    - Mixed: 1, 2 3 (commas take precedence)
+
+    Args:
+        text: User-entered text (e.g., "0.1, 0.2" or "0.1 0.2" or "[0.1, 0.2]").
+        list_type: Element type for coercion ("int", "float", "string", "file").
+                   If None, no coercion is applied.
+
+    Returns:
+        A Python list of parsed and (optionally) coerced values.
+
+    Raises:
+        ValueError: If parsing fails or coercion is impossible.
+        SyntaxError: If literal_eval encounters invalid syntax.
+    """
+    text = text.strip()
+    if not text:
+        return []
+
+    try:
+        parsed = ast.literal_eval(text)
+        if isinstance(parsed, (list, tuple)):
+            result = list(parsed)
+        else:
+            result = [parsed]
+    except (ValueError, SyntaxError):
+        if "," in text:
+            parts = text.split(",")
+        else:
+            parts = text.split()
+
+        result = []
+        for part in parts:
+            part = part.strip()
+            if not part:
+                continue
+            try:
+                result.append(ast.literal_eval(part))
+            except (ValueError, SyntaxError):
+                result.append(part)
+
+    if list_type:
+        coerced = []
+        for item in result:
+            if list_type in ("int", "float"):
+                coerced.append(float(item) if list_type == "float" else int(item))
+            elif list_type in ("string", "file"):
+                coerced.append(str(item))
+            else:
+                coerced.append(item)
+        result = coerced
+
+    return result
+
+
+def _format_list_text(value):
+    """Format a list as bracket-free, comma-separated text for canonical display.
+
+    Args:
+        value: A list or tuple to format.
+
+    Returns:
+        A string like "0.1, 0.2, 0.3" (no brackets).
+    """
+    if not value:
+        return ""
+    return ", ".join(str(v) for v in value)
+
+
 class SettingsFactory:
     """Factory for creating settings input widgets and managing settings."""
 
@@ -621,12 +697,16 @@ class SettingsFactory:
                     # Override prefilled value from entry_data (not config_dict)
                     if field_name in entry_data and entry_data[field_name] is not None:
                         unwrapped = unwrap_composite_widget(field_widget)
-                        value_str = str(entry_data[field_name])
                         if isinstance(unwrapped, QCheckBox):
                             unwrapped.setChecked(bool(entry_data[field_name]))
                         elif isinstance(unwrapped, QComboBox):
-                            unwrapped.setCurrentText(value_str)
+                            unwrapped.setCurrentText(str(entry_data[field_name]))
                         else:  # QLineEdit
+                            # Use canonical format for list fields
+                            if unwrapped.property("darsia_is_list"):
+                                value_str = _format_list_text(entry_data[field_name])
+                            else:
+                                value_str = str(entry_data[field_name])
                             unwrapped.setText(value_str)
 
                     field_widgets[field_name] = field_widget
@@ -1379,7 +1459,10 @@ class SettingsFactory:
 
         setting_edit = QLineEdit()
         if value is not None:
-            setting_edit.setText(str(value))
+            if setting_dict["type"] == "list":
+                setting_edit.setText(_format_list_text(value))
+            else:
+                setting_edit.setText(str(value))
 
         # Set placeholder text if provided
         placeholder = setting_dict.get("placeholder")
@@ -1394,9 +1477,16 @@ class SettingsFactory:
 
         # Type annotation label
         if setting_dict["type"] == "list":
-            type_label = QLabel(
-                f"({setting_dict['type']}, {setting_dict['list_type']})"
-            )
+            if setting_dict.get("fixed_length") is not None:
+                # Fixed-size tuple: show the arity (e.g., "2 x float" for tuple[float, float])
+                arity = setting_dict["fixed_length"]
+                elem_type = setting_dict["list_type"]
+                type_label = QLabel(f"({arity} x {elem_type})")
+            else:
+                # Variable-length list
+                type_label = QLabel(
+                    f"({setting_dict['type']}, {setting_dict['list_type']})"
+                )
         else:
             type_label = QLabel(f"({setting_dict['type']})")
 
@@ -1408,6 +1498,47 @@ class SettingsFactory:
 
         # Store reference to the real control for unwrapping in sync
         field_widget.setProperty("value_widget", setting_edit)
+
+        # Tag list fields so the save pass can identify and parse them specially
+        if setting_dict["type"] == "list":
+            list_type = setting_dict.get("list_type")
+            fixed_length = setting_dict.get("fixed_length")
+
+            setting_edit.setProperty("darsia_is_list", True)
+            setting_edit.setProperty("darsia_list_type", list_type)
+            # Tag fixed-length fields (derived from tuple arity)
+            if fixed_length is not None:
+                setting_edit.setProperty("darsia_fixed_length", fixed_length)
+
+                def normalize_list(se=setting_edit, lt=list_type, fl=fixed_length):
+                    text = se.text()
+                    if not text.strip():
+                        se.setStyleSheet("")
+                        se.setToolTip("")
+                        return
+                    try:
+                        parsed = _parse_list_text(text, lt)
+                    except (ValueError, SyntaxError) as e:
+                        se.setStyleSheet("border: 1px solid #d32f2f;")
+                        se.setToolTip(f"Invalid list value: {e}")
+                        return
+
+                    # Truncate to fixed length if too long
+                    if len(parsed) > fl:
+                        parsed = parsed[:fl]
+                        se.setText(_format_list_text(parsed))
+
+                    # Mark red if too short
+                    if len(parsed) < fl:
+                        se.setStyleSheet("border: 1px solid #d32f2f;")
+                        se.setToolTip(
+                            f"Expected exactly {fl} entries, got {len(parsed)}."
+                        )
+                    else:
+                        se.setStyleSheet("")
+                        se.setToolTip("")
+
+                setting_edit.editingFinished.connect(normalize_list)
 
         return display_name, field_widget
 
@@ -2167,11 +2298,17 @@ class SettingsFactory:
                     # placeholder
                     if value.text() == NO_FILE_CHOSEN or value.text().strip() == "":
                         continue
-                    self.set_value(
-                        self.main_window.config_dict,
-                        key,
-                        ast.literal_eval(value.text()),
-                    )
+                    # Check if this is a list field (tagged during widget creation)
+                    if value.property("darsia_is_list"):
+                        list_type = value.property("darsia_list_type")
+                        parsed_value = _parse_list_text(value.text(), list_type)
+                        self.set_value(self.main_window.config_dict, key, parsed_value)
+                    else:
+                        self.set_value(
+                            self.main_window.config_dict,
+                            key,
+                            ast.literal_eval(value.text()),
+                        )
                 elif isinstance(value, QComboBox):
                     self.set_value(
                         self.main_window.config_dict, key, value.currentText()
@@ -2370,15 +2507,15 @@ class SettingsFactory:
                                     except ValueError:
                                         pass
                                 elif field_type == "list":
-                                    # Parse list fields via literal_eval
-                                    # (e.g., corner_1 = [x, y])
+                                    # Parse list fields with per-element-type coercion
                                     try:
-                                        parsed = ast.literal_eval(text_value)
-                                        if isinstance(parsed, list):
-                                            extracted_value = parsed
-                                            should_include = (
-                                                extracted_value != field_default
-                                            )
+                                        list_type = field_schema.get("list_type")
+                                        extracted_value = _parse_list_text(
+                                            text_value, list_type
+                                        )
+                                        should_include = (
+                                            extracted_value != field_default
+                                        )
                                     except (ValueError, SyntaxError):
                                         pass
                                 elif field_type == "time":

--- a/src/darsia/presets/workflows/config/corrections.py
+++ b/src/darsia/presets/workflows/config/corrections.py
@@ -209,45 +209,45 @@ class CropCorrectionConfig:
         in_meters: Whether width/height are in meters (default: True).
     """
 
-    top_left: list[int] | None = field(
+    top_left: tuple[int, int] | None = field(
         default=None,
         metadata={
             "name": "Top-left corner",
             "help": (
-                "Top-left corner as [row, col] in pixels. "
+                "Top-left corner as row, col in pixels. "
                 "Row is vertical (0 at top), col is horizontal (0 at left)."
             ),
-            "placeholder": "e.g., [47, 415]",
+            "placeholder": "e.g., 47, 415",
             "legacy_source": "pts_src",
             "legacy_index": 0,
         },
     )
-    bottom_left: list[int] | None = field(
+    bottom_left: tuple[int, int] | None = field(
         default=None,
         metadata={
             "name": "Bottom-left corner",
-            "help": "Bottom-left corner as [row, col] in pixels.",
-            "placeholder": "e.g., [7886, 448]",
+            "help": "Bottom-left corner as row, col in pixels.",
+            "placeholder": "e.g., 7886, 448",
             "legacy_source": "pts_src",
             "legacy_index": 1,
         },
     )
-    bottom_right: list[int] | None = field(
+    bottom_right: tuple[int, int] | None = field(
         default=None,
         metadata={
             "name": "Bottom-right corner",
-            "help": "Bottom-right corner as [row, col] in pixels.",
-            "placeholder": "e.g., [7829, 5228]",
+            "help": "Bottom-right corner as row, col in pixels.",
+            "placeholder": "e.g., 7829, 5228",
             "legacy_source": "pts_src",
             "legacy_index": 2,
         },
     )
-    top_right: list[int] | None = field(
+    top_right: tuple[int, int] | None = field(
         default=None,
         metadata={
             "name": "Top-right corner",
-            "help": "Top-right corner as [row, col] in pixels.",
-            "placeholder": "e.g., [110, 5263]",
+            "help": "Top-right corner as row, col in pixels.",
+            "placeholder": "e.g., 110, 5263",
             "legacy_source": "pts_src",
             "legacy_index": 3,
         },
@@ -304,12 +304,14 @@ class CropCorrectionConfig:
             sec.get("top_right"),
         ]
 
+        make_tuple = lambda c: tuple(c) if c is not None else None
+
         if all(c is not None for c in corners):
             # All 4 corners provided — assemble into pts_src
-            self.top_left = corners[0]
-            self.bottom_left = corners[1]
-            self.bottom_right = corners[2]
-            self.top_right = corners[3]
+            self.top_left = make_tuple(corners[0])
+            self.bottom_left = make_tuple(corners[1])
+            self.bottom_right = make_tuple(corners[2])
+            self.top_right = make_tuple(corners[3])
             self.pts_src = corners
         else:
             # Fall back to flat pts_src (backward compatibility)
@@ -317,10 +319,10 @@ class CropCorrectionConfig:
             # If pts_src was provided, try to extract corners for round-trip
             if self.pts_src is not None:
                 if len(self.pts_src) == 4:
-                    self.top_left = self.pts_src[0]
-                    self.bottom_left = self.pts_src[1]
-                    self.bottom_right = self.pts_src[2]
-                    self.top_right = self.pts_src[3]
+                    self.top_left = make_tuple(self.pts_src[0])
+                    self.bottom_left = make_tuple(self.pts_src[1])
+                    self.bottom_right = make_tuple(self.pts_src[2])
+                    self.top_right = make_tuple(self.pts_src[3])
 
         self.width = float(sec.get("width", self.width))
         self.height = float(sec.get("height", self.height))

--- a/src/darsia/presets/workflows/config/restoration.py
+++ b/src/darsia/presets/workflows/config/restoration.py
@@ -154,7 +154,7 @@ class RestorationConfig:
         metadata={
             "name": "Ignore regions",
             "help": "List of region/label names to exclude from restoration.",
-            "placeholder": "e.g., ['label1', 'label2']",
+            "placeholder": "e.g., label1, label2",
         },
     )
 

--- a/src/darsia/presets/workflows/config/roi.py
+++ b/src/darsia/presets/workflows/config/roi.py
@@ -22,20 +22,20 @@ class RoiConfig:
             "help": "Unique registry key for this ROI.",
         },
     )
-    corner_1: list[float] = field(
-        default_factory=list,
+    corner_1: tuple[float, float] = field(
+        default=(0.0, 0.0),
         metadata={
             "name": "Corner 1",
-            "help": "First corner coordinate as [x, y].",
-            "placeholder": "[x, y]",
+            "help": "First corner coordinate as x, y.",
+            "placeholder": "x, y",
         },
     )
-    corner_2: list[float] = field(
-        default_factory=list,
+    corner_2: tuple[float, float] = field(
+        default=(0.0, 0.0),
         metadata={
             "name": "Corner 2",
-            "help": "Second corner coordinate as [x, y].",
-            "placeholder": "[x, y]",
+            "help": "Second corner coordinate as x, y.",
+            "placeholder": "x, y",
         },
     )
     label: int | None = field(
@@ -53,8 +53,8 @@ class RoiConfig:
 
     def load(self, sec: dict) -> "RoiConfig":
         self.name = _get_key(sec, "name", required=True, type_=str)
-        self.corner_1 = _get_key(sec, "corner_1", required=True, type_=list)
-        self.corner_2 = _get_key(sec, "corner_2", required=True, type_=list)
+        self.corner_1 = _get_key(sec, "corner_1", required=True, type_=tuple)
+        self.corner_2 = _get_key(sec, "corner_2", required=True, type_=tuple)
         self.label = _get_key(sec, "label", required=False, type_=int, default=None)
         return self
 

--- a/src/darsia/presets/workflows/config/segmentation.py
+++ b/src/darsia/presets/workflows/config/segmentation.py
@@ -24,7 +24,7 @@ class SegmentationValueLabelsConfig:
 
     show_values: bool = False
     """Whether to plot threshold values along contours."""
-    value_color: list[int] = field(default_factory=list)
+    value_color: tuple[int, int, int] = field(default=(0, 0, 0))
     """RGB color for contour value labels."""
     value_size: float = 0.5
     """Font scale for contour value labels."""
@@ -46,7 +46,7 @@ class SegmentationValueLabelsConfig:
             sec, "show_values", default=False, required=False, type_=bool
         )
         self.value_color = _get_key(
-            sec, "value_color", default=default_color, required=False, type_=list
+            sec, "value_color", default=default_color, required=False, type_=tuple
         )
         self.value_size = _get_key(
             sec, "value_size", default=0.5, required=False, type_=float
@@ -79,7 +79,7 @@ class SegmentationConfig:
     """Type for segmentation."""
     thresholds: list[float] = field(default_factory=list)
     """List of thresholds."""
-    color: list[int, int, int] = field(default_factory=list)
+    color: tuple[int, int, int] = field(default=(0, 0, 0))
     """RGB color for contours."""
     alpha: list[float] = field(default_factory=list)
     """Alpha values for contours."""
@@ -101,7 +101,7 @@ class SegmentationConfig:
             self.mode, color_embedding_registry, "analysis.segmentation.mode"
         )
         self.thresholds = _get_key(sec, "thresholds", required=True, type_=list)
-        self.color = _get_key(sec, "color", required=True, type_=list)
+        self.color = _get_key(sec, "color", required=True, type_=tuple)
         self.alpha = _get_key(sec, "alpha", required=False, type_=list)
         if not self.alpha:
             self.alpha = [1.0] * len(self.thresholds)

--- a/src/darsia/presets/workflows/config/time_data.py
+++ b/src/darsia/presets/workflows/config/time_data.py
@@ -304,10 +304,10 @@ class PathData:
             "name": "Image paths",
             "help": (
                 "List of image file paths (supports glob patterns with *). "
-                "Format: ['file1.jpg', 'file2.jpg']"
+                "Format: file1.jpg, file2.jpg"
             ),
             "group": "Paths",
-            "placeholder": "['file1.jpg', 'file2.jpg', 'DSC*.JPG', '*']",
+            "placeholder": "file1.jpg, file2.jpg, DSC*.JPG, *",
         },
     )
     """List of image file paths."""

--- a/tests/unit/test_corrections_config.py
+++ b/tests/unit/test_corrections_config.py
@@ -242,10 +242,10 @@ class TestCurvatureCorrectionConfigLoad:
         )
         cfg = CorrectionsConfig().load(cfg_path)
         assert cfg.curvature.crop is not None
-        assert cfg.curvature.crop.top_left == [47, 415]
-        assert cfg.curvature.crop.bottom_left == [7886, 448]
-        assert cfg.curvature.crop.bottom_right == [7829, 5228]
-        assert cfg.curvature.crop.top_right == [110, 5263]
+        assert cfg.curvature.crop.top_left == (47, 415)
+        assert cfg.curvature.crop.bottom_left == (7886, 448)
+        assert cfg.curvature.crop.bottom_right == (7829, 5228)
+        assert cfg.curvature.crop.top_right == (110, 5263)
         # pts_src should be assembled from corners in order
         assert cfg.curvature.crop.pts_src == [
             [47, 415],

--- a/tests/unit/test_segmentation_contour_values.py
+++ b/tests/unit/test_segmentation_contour_values.py
@@ -31,7 +31,7 @@ def test_segmentation_config_value_labels_defaults():
     }
     cfg = SegmentationConfig().load(sec)
     assert cfg.values.show_values is False
-    assert cfg.values.value_color == [255, 0, 0]
+    assert cfg.values.value_color == (255, 0, 0)
     assert cfg.values.value_size == 0.5
     assert cfg.values.value_alpha == 1.0
     assert cfg.values.value_max_per_contour == 3
@@ -59,7 +59,7 @@ def test_segmentation_config_value_labels_nested_override():
     }
     cfg = SegmentationConfig().load(sec)
     assert cfg.values.show_values is True
-    assert cfg.values.value_color == [1, 2, 3]
+    assert cfg.values.value_color == (1, 2, 3)
     assert cfg.values.value_size == 0.9
     assert cfg.values.value_alpha == 0.6
     assert cfg.values.value_density == 1.0


### PR DESCRIPTION
This pull request introduces robust support for fixed-length tuple fields in the configuration dataclasses and their corresponding GUI settings widgets. The changes enable the GUI to correctly display, parse, validate, and save tuple fields (e.g., `tuple[int, int]`) as fixed-length lists, improving user experience and preventing input errors. Additionally, list and tuple fields now use a more user-friendly, bracket-free, comma-separated text format in the GUI, and all relevant placeholders and help texts are updated for clarity.

**Support for tuple fields and improved list handling:**

* Added `_infer_fixed_length` to detect tuple arity in type annotations, enabling the schema to distinguish between fixed-length tuples and variable-length lists (`src/darsia/gui/ui/schema/dataclass_introspection.py`) [[1]](diffhunk://#diff-9a3a56645656566550fd9a2d83b6eab7259e5efb4bf4c095d10e82e52c8042a0R192-R208) [[2]](diffhunk://#diff-9a3a56645656566550fd9a2d83b6eab7259e5efb4bf4c095d10e82e52c8042a0L265-R286).
* Updated settings widget creation to display tuple fields as fixed-length lists, show arity in type labels, and validate input length with user feedback (red border for wrong length) (`src/darsia/gui/ui/settings.py`) [[1]](diffhunk://#diff-6269baaad21d2a42b272d2c2438703ae4c8206c44f7ec96db24fa041aceec5fdR1462-R1464) [[2]](diffhunk://#diff-6269baaad21d2a42b272d2c2438703ae4c8206c44f7ec96db24fa041aceec5fdR1480-R1486) [[3]](diffhunk://#diff-6269baaad21d2a42b272d2c2438703ae4c8206c44f7ec96db24fa041aceec5fdR1502-R1542).
* Implemented `_parse_list_text` and `_format_list_text` for robust, user-friendly parsing and display of list/tuple values in the GUI, supporting multiple input formats and per-element type coercion (`src/darsia/gui/ui/settings.py`) [[1]](diffhunk://#diff-6269baaad21d2a42b272d2c2438703ae4c8206c44f7ec96db24fa041aceec5fdR41-R116) [[2]](diffhunk://#diff-6269baaad21d2a42b272d2c2438703ae4c8206c44f7ec96db24fa041aceec5fdL624-R709).

**Synchronization and parsing improvements:**

* Ensured that list and tuple fields are parsed and saved using the new parsing logic, both when syncing GUI inputs to the config dictionary and when extracting values for saving (`src/darsia/gui/ui/settings.py`) [[1]](diffhunk://#diff-6269baaad21d2a42b272d2c2438703ae4c8206c44f7ec96db24fa041aceec5fdR2301-R2306) [[2]](diffhunk://#diff-6269baaad21d2a42b272d2c2438703ae4c8206c44f7ec96db24fa041aceec5fdL2373-R2515).

**Configuration dataclass updates and placeholder improvements:**

* Changed relevant fields in configuration dataclasses from `list[...]` to `tuple[...]` where appropriate (e.g., coordinates, colors), updated placeholders and help texts to use comma-separated values without brackets, and adjusted loading logic to ensure tuples are used throughout (`src/darsia/presets/workflows/config/corrections.py`, `src/darsia/presets/workflows/config/roi.py`, `src/darsia/presets/workflows/config/segmentation.py`, `src/darsia/presets/workflows/config/time_data.py`, `src/darsia/presets/workflows/config/restoration.py`) [[1]](diffhunk://#diff-1b4a7280c6ab2d54fda19bb5fda1bcf9c4018adc091e18aab7e8beebe5fdab42L212-R250) [[2]](diffhunk://#diff-1b4a7280c6ab2d54fda19bb5fda1bcf9c4018adc091e18aab7e8beebe5fdab42R307-R325) [[3]](diffhunk://#diff-10cb3e7c778ea0688674db983f910ce843bd27818b1d4e94d4922763013224abL25-R38) [[4]](diffhunk://#diff-10cb3e7c778ea0688674db983f910ce843bd27818b1d4e94d4922763013224abL56-R57) [[5]](diffhunk://#diff-913c7bef0fe34a822461cbf90b15adec220604a280a822c2943c92bf624ac912L27-R27) [[6]](diffhunk://#diff-913c7bef0fe34a822461cbf90b15adec220604a280a822c2943c92bf624ac912L49-R49) [[7]](diffhunk://#diff-913c7bef0fe34a822461cbf90b15adec220604a280a822c2943c92bf624ac912L82-R82) [[8]](diffhunk://#diff-913c7bef0fe34a822461cbf90b15adec220604a280a822c2943c92bf624ac912L104-R104) [[9]](diffhunk://#diff-857611e4aa5b54876ec5dc40c909db9e6009bff3baf1d4583ba89b63d50d8241L307-R310) [[10]](diffhunk://#diff-dfab5f0be18111271fa7a3d0b1f686f12c55617853473467a68e45c30bfdf1a3L157-R157).