### PR TITLE
Fix typing restoration

### DIFF
--- a/src/darsia/presets/workflows/config/restoration.py
+++ b/src/darsia/presets/workflows/config/restoration.py
@@ -10,16 +10,18 @@ from .utils import _get_key, _get_section_from_toml
 
 @dataclass
 class VolumeAveragingConfig:
-    rev_size: int = field(
-        default=3,
+    rev_size: float = field(
+        default=0.005,
         metadata={
             "name": "Revision size",
-            "help": "Size of the averaging kernel (number of neighboring voxels to average).",
+            "help": "Size of the representative elementary volume (REV) in meters.",
         },
     )
 
     def load(self, sec: dict) -> "VolumeAveragingConfig":
-        self.rev_size = _get_key(sec, "rev_size", self.rev_size, required=False)
+        self.rev_size = _get_key(
+            sec, "rev_size", self.rev_size, required=False, type_=float
+        )
         return self
 
 

--- a/src/darsia/restoration/averaging.py
+++ b/src/darsia/restoration/averaging.py
@@ -23,7 +23,7 @@ class REV:
             img (Image): image, used for determining the number of voxels
 
         """
-        if isinstance(size, float):
+        if isinstance(size, (int, float)):
             size = [size] * img.coordinatesystem.dim
         self.size: int = max(
             [

--- a/tests/unit/test_restoration_config.py
+++ b/tests/unit/test_restoration_config.py
@@ -22,18 +22,18 @@ def test_restoration_config_volume_average_defaults(tmp_path):
     cfg = RestorationConfig().load(cfg_path)
     assert cfg.method == "volume_average"
     assert isinstance(cfg.options, VolumeAveragingConfig)
-    assert cfg.options.rev_size == 3  # default
+    assert cfg.options.rev_size == pytest.approx(0.005)  # default
 
 
 def test_restoration_config_volume_average_custom_rev_size(tmp_path):
     cfg_path = _write_toml(
         tmp_path,
-        '[restoration]\nmethod = "volume_average"\n\n[restoration.options]\nrev_size = 5\n',
+        '[restoration]\nmethod = "volume_average"\n\n[restoration.options]\nrev_size = 0.01\n',
     )
     cfg = RestorationConfig().load(cfg_path)
     assert cfg.method == "volume_average"
     assert isinstance(cfg.options, VolumeAveragingConfig)
-    assert cfg.options.rev_size == 5
+    assert cfg.options.rev_size == pytest.approx(0.01)
 
 
 def test_restoration_config_tvd_defaults(tmp_path):

--- a/tests/unit/test_restoration_workflow.py
+++ b/tests/unit/test_restoration_workflow.py
@@ -35,7 +35,7 @@ def test_build_restoration_applies_boolean_porosity_ignore_mask_to_volume_averag
 
     restoration_config = RestorationConfig(
         method="volume_average",
-        options=VolumeAveragingConfig(rev_size=3),
+        options=VolumeAveragingConfig(rev_size=0.005),
         ignore=["boolean_porosity"],
     )
     baseline = darsia.ScalarImage(np.zeros((2, 2), dtype=float), space_dim=2)
@@ -111,3 +111,22 @@ def test_build_restoration_unknown_ignore_mask_raises():
 
     with pytest.raises(ValueError, match="Unknown restoration ignore mask"):
         build_restoration(restoration_config, fluidflower)
+
+
+def test_build_restoration_volume_averaging_with_default_rev_size():
+    """Regression test: VolumeAveragingConfig default rev_size works with real REV."""
+    restoration_config = RestorationConfig(
+        method="volume_average",
+        options=VolumeAveragingConfig(),  # Use default rev_size (0.005)
+    )
+    baseline = darsia.ScalarImage(np.zeros((10, 10), dtype=float), space_dim=2)
+    image_porosity = darsia.ScalarImage(np.ones((10, 10), dtype=float), space_dim=2)
+    fluidflower = SimpleNamespace(
+        baseline=baseline,
+        image_porosity=image_porosity,
+    )
+
+    # Should not raise TypeError about int not being subscriptable
+    restoration = build_restoration(restoration_config, fluidflower)
+    assert restoration is not None
+    assert isinstance(restoration, darsia.VolumeAveraging)


### PR DESCRIPTION
This pull request updates the default behavior and type handling for the `rev_size` parameter in the volume averaging restoration workflow, shifting it from an integer (voxel count) to a float (physical size in meters). It also updates related documentation, tests, and type checks to ensure consistency and correctness.

**Config and Type Handling Updates:**

* Changed the `rev_size` field in `VolumeAveragingConfig` from `int` to `float`, updated its default value from `3` to `0.005`, and clarified the help text to indicate the unit is meters instead of voxels. The loading method now enforces `float` type for `rev_size`.
* Updated the constructor in `averaging.py` to accept both `int` and `float` for the `size` parameter, ensuring compatibility with the new `rev_size` type.

**Test Adjustments and Additions:**

* Updated unit tests to reflect the new default and custom `rev_size` values as floats, using `pytest.approx` for floating-point comparisons.
* Updated workflow tests to use the new default `rev_size` value of `0.005` in test configurations.
* Added a regression test to ensure that the default `rev_size` (as a float) works correctly with real data and does not raise type errors.