### PR TITLE
Custom tab selection

### DIFF
--- a/src/darsia/gui/ui/schema/section_registry.py
+++ b/src/darsia/gui/ui/schema/section_registry.py
@@ -222,6 +222,7 @@ def filter_visible_sections(
 
     Returns:
         Filtered tuple of section names to display (always includes unmet ones).
+        Order follows TAB_VISIBILITY's declared sequence (if set).
     """
     wanted = TAB_VISIBILITY.get((action, checkbox_id))
 
@@ -229,18 +230,25 @@ def filter_visible_sections(
     if wanted is None:
         return required_sections
 
-    # Filter to wanted sections, but force-show unsatisfied ones
-    visible = []
-    seen = set()
-
-    for section in required_sections:
-        # Extract base name for matching (e.g., "calibration.color" -> "calibration")
+    def _include(section: str) -> bool:
         base = section.split(".")[0]
+        return base in wanted or not _is_section_satisfied(config_dict, section)
 
-        # If wanted OR unsatisfied, include it
-        if base in wanted or not _is_section_satisfied(config_dict, section):
-            if section not in seen:
+    visible: list[str] = []
+    seen: set[str] = set()
+
+    # Pass 1: order by `wanted`'s declared sequence, matching sections by base
+    for base in wanted:
+        for section in required_sections:
+            section_base = section.split(".")[0]
+            if section_base == base and section not in seen and _include(section):
                 visible.append(section)
                 seen.add(section)
+
+    # Pass 2: append any remaining sections not yet added (preserve original order)
+    for section in required_sections:
+        if section not in seen and _include(section):
+            visible.append(section)
+            seen.add(section)
 
     return tuple(visible)

--- a/src/darsia/gui/ui/schema/section_registry.py
+++ b/src/darsia/gui/ui/schema/section_registry.py
@@ -8,6 +8,10 @@ Composite entries are lists of other (action, checkbox_id) keys whose sections s
 be unioned together.
 """
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 # Mapping: (action, checkbox_id) -> (module_path, function_name) | list[(action, checkbox_id)]
 #
 # Leaf entries: (module_path, function_name) — resolves a function decorated with
@@ -80,6 +84,15 @@ CHECKBOX_TO_SECTIONS = {
     ),
 }
 
+# Tab visibility override: limit which sections are shown for specific workflows.
+# If a (action, checkbox_id) key is absent, all required sections are shown.
+# Used for workflows where some required sections are always pre-populated by
+# an earlier step (e.g., Setup) and would just add visual clutter here.
+TAB_VISIBILITY = {
+    ("calibration", "color"): ("color", "calibration", "options"),
+    ("calibration", "mass"): ("color", "calibration", "options"),
+}
+
 
 def get_required_sections(action: str, checkbox_id: str) -> tuple[str, ...] | None:
     """Get the required config sections for a checkbox.
@@ -135,3 +148,75 @@ def get_required_sections(action: str, checkbox_id: str) -> tuple[str, ...] | No
         if isinstance(e, ValueError):
             raise
         raise ValueError(f"Error loading sections for {action}.{checkbox_id}: {e}")
+
+
+def _is_section_satisfied(config_dict: dict, section: str) -> bool:
+    """Check whether a section already has a non-empty value in the GUI's
+    TOML-parsed config dict.
+
+    Args:
+        config_dict: The GUI's raw config dict (main_window.config_dict).
+        section: Section name (e.g., "rig", "calibration.color").
+
+    Returns:
+        True if the section key path resolves to a non-empty dict or value;
+        False otherwise.
+    """
+    if not isinstance(config_dict, dict):
+        return False
+    try:
+        value = config_dict
+        for key in section.split("."):
+            if not isinstance(value, dict) or key not in value:
+                return False
+            value = value[key]
+        # Section is satisfied if the final value is non-empty dict or non-None
+        return bool(value) if isinstance(value, dict) else value is not None
+    except Exception as e:
+        logger.debug(f"Error checking section {section}: {e}")
+        return False
+
+
+def filter_visible_sections(
+    action: str,
+    checkbox_id: str,
+    required_sections: tuple[str, ...],
+    config_dict: dict,
+) -> tuple[str, ...]:
+    """Filter visible sections based on customization, force-showing unmet ones.
+
+    Ensures no required section is hidden if it's not yet satisfied in the
+    config. Only displays sections listed in tab_customization.toml unless
+    they are currently unsatisfied (missing/empty).
+
+    Args:
+        action: Workflow action (e.g., "calibration").
+        checkbox_id: Checkbox ID (e.g., "color").
+        required_sections: Tuple of required sections from the decorator.
+        config_dict: The GUI's raw TOML-parsed config dict
+            (main_window.config_dict).
+
+    Returns:
+        Filtered tuple of section names to display (always includes unmet ones).
+    """
+    wanted = TAB_VISIBILITY.get((action, checkbox_id))
+
+    # No customization for this action/checkbox; show all required sections
+    if wanted is None:
+        return required_sections
+
+    # Filter to wanted sections, but force-show unsatisfied ones
+    visible = []
+    seen = set()
+
+    for section in required_sections:
+        # Extract base name for matching (e.g., "calibration.color" -> "calibration")
+        base = section.split(".")[0]
+
+        # If wanted OR unsatisfied, include it
+        if base in wanted or not _is_section_satisfied(config_dict, section):
+            if section not in seen:
+                visible.append(section)
+                seen.add(section)
+
+    return tuple(visible)

--- a/src/darsia/gui/ui/schema/section_registry.py
+++ b/src/darsia/gui/ui/schema/section_registry.py
@@ -20,9 +20,18 @@ logger = logging.getLogger(__name__)
 #   sections (in order, deduplicated)
 CHECKBOX_TO_SECTIONS = {
     # Setup leaf mappings — point to the functions the GUI's setup.py::run_setup() calls
+    # Ordered to match sidebar layout (Preparation → Setup steps).
     ("setup", "protocols"): (
         "darsia.presets.workflows.setup.setup_protocols",
         "setup_imaging_protocol",
+    ),
+    ("setup", "crop"): (
+        "darsia.presets.workflows.setup.setup_crop",
+        "setup_crop_correction",
+    ),
+    ("setup", "rig"): (
+        "darsia.presets.workflows.setup.setup_rig",
+        "setup_rig",
     ),
     ("setup", "depth"): (
         "darsia.presets.workflows.setup.setup_depth",
@@ -36,12 +45,8 @@ CHECKBOX_TO_SECTIONS = {
         "darsia.presets.workflows.setup.setup_facies",
         "setup_facies",
     ),
-    ("setup", "rig"): (
-        "darsia.presets.workflows.setup.setup_rig",
-        "setup_rig",
-    ),
-    # Setup composite mapping: "all" runs depth + segmentation + facies + rig (no protocol)
-    # Mirrors setup.py:104-115 run_setup() logic exactly.
+    # Setup composite mapping: "all" runs depth + segmentation + facies + rig
+    # (no protocols/crop)
     ("setup", "all"): [
         ("setup", "depth"),
         ("setup", "segmentation"),
@@ -89,6 +94,25 @@ CHECKBOX_TO_SECTIONS = {
 # Used for workflows where some required sections are always pre-populated by
 # an earlier step (e.g., Setup) and would just add visual clutter here.
 TAB_VISIBILITY = {
+    # Setup > Preparation
+    ("setup", "protocols"): ("data", "protocols"),
+    ("setup", "crop"): ("rig", "corrections", "options"),
+    # Setup > Full setup
+    ("setup", "all"): (
+        "rig",
+        "depth",
+        "labeling",
+        "facies",
+        "image_porosity",
+        "corrections",
+        "options",
+    ),
+    # Setup > Single steps
+    ("setup", "depth"): ("depth", "options"),
+    ("setup", "segmentation"): ("labeling", "options"),
+    ("setup", "facies"): ("facies", "options"),
+    ("setup", "rig"): ("rig", "corrections", "image_porosity", "options"),
+    # Calibration > Color & Mass
     ("calibration", "color"): ("color", "calibration", "options"),
     ("calibration", "mass"): ("color", "calibration", "options"),
 }

--- a/src/darsia/gui/ui/schema/section_registry.py
+++ b/src/darsia/gui/ui/schema/section_registry.py
@@ -19,8 +19,7 @@ logger = logging.getLogger(__name__)
 # Composite entries: list of (action, checkbox_id) keys — union of those checkboxes'
 #   sections (in order, deduplicated)
 CHECKBOX_TO_SECTIONS = {
-    # Setup leaf mappings — point to the functions the GUI's setup.py::run_setup() calls
-    # Ordered to match sidebar layout (Preparation → Setup steps).
+    # Setup leaf mappings — preparation steps (protocols, crop).
     ("setup", "protocols"): (
         "darsia.presets.workflows.setup.setup_protocols",
         "setup_imaging_protocol",
@@ -29,6 +28,14 @@ CHECKBOX_TO_SECTIONS = {
         "darsia.presets.workflows.setup.setup_crop",
         "setup_crop_correction",
     ),
+    # Setup composite mapping - full setup
+    ("setup", "all"): [
+        ("setup", "depth"),
+        ("setup", "segmentation"),
+        ("setup", "facies"),
+        ("setup", "rig"),
+    ],
+    # Setup leaf mappings — individual steps
     ("setup", "rig"): (
         "darsia.presets.workflows.setup.setup_rig",
         "setup_rig",
@@ -45,14 +52,6 @@ CHECKBOX_TO_SECTIONS = {
         "darsia.presets.workflows.setup.setup_facies",
         "setup_facies",
     ),
-    # Setup composite mapping: "all" runs depth + segmentation + facies + rig
-    # (no protocols/crop)
-    ("setup", "all"): [
-        ("setup", "depth"),
-        ("setup", "segmentation"),
-        ("setup", "facies"),
-        ("setup", "rig"),
-    ],
     # Calibration leaf mappings
     ("calibration", "color"): (
         "darsia.presets.workflows.calibration.calibration_color_paths",
@@ -210,8 +209,9 @@ def filter_visible_sections(
     """Filter visible sections based on customization, force-showing unmet ones.
 
     Ensures no required section is hidden if it's not yet satisfied in the
-    config. Only displays sections listed in tab_customization.toml unless
-    they are currently unsatisfied (missing/empty).
+    config. When TAB_VISIBILITY is defined, its tuple order determines display
+    order; only displays sections listed in TAB_VISIBILITY unless they are
+    currently unsatisfied (missing/empty).
 
     Args:
         action: Workflow action (e.g., "calibration").

--- a/src/darsia/gui/ui/settings.py
+++ b/src/darsia/gui/ui/settings.py
@@ -28,7 +28,7 @@ from .schema.dataclass_introspection import (
     SECTION_LOADABLE,
     get_section_fields,
 )
-from .schema.section_registry import get_required_sections
+from .schema.section_registry import filter_visible_sections, get_required_sections
 
 
 def unwrap_composite_widget(value):
@@ -278,6 +278,12 @@ class SettingsFactory:
                     f"No settings mapping found for {action}.{checked_id}"
                 )
                 continue
+
+            # Apply tab customization filter (force-show unsatisfied sections)
+            config_dict = self.main_window.config_dict
+            sections = filter_visible_sections(
+                action, checked_id, sections, config_dict
+            )
 
             # For each required section, get its fields (avoiding duplicates)
             for section in sections:

--- a/src/darsia/gui/ui/setup.py
+++ b/src/darsia/gui/ui/setup.py
@@ -173,7 +173,6 @@ class SetupTab:
             (
                 "Setup steps",
                 [
-                    ("Rig", "rig", "fa5s.circle", get_help_text("setup", "rig", "Rig")),
                     (
                         "Depth",
                         "depth",
@@ -192,6 +191,7 @@ class SetupTab:
                         "fa5s.circle",
                         get_help_text("setup", "facies", "Facies"),
                     ),
+                    ("Rig", "rig", "fa5s.circle", get_help_text("setup", "rig", "Rig")),
                 ],
             ),
         ]


### PR DESCRIPTION
This pull request introduces enhancements to the GUI workflow configuration system, focusing on improved section visibility controls and more flexible handling of required sections in the setup and calibration workflows. The main improvements include the addition of a tab visibility override mechanism, logic to ensure required sections are always shown if unsatisfied, and some refactoring for clarity and maintainability.

**Key changes:**

### Section visibility customization and logic

* Added a `TAB_VISIBILITY` mapping in `section_registry.py` to control which configuration sections are visible for each workflow step, reducing visual clutter and improving user experience.
* Implemented the `filter_visible_sections` function to filter and order visible sections based on the `TAB_VISIBILITY` mapping, always displaying any required section that is not yet satisfied in the configuration.
* Added the `_is_section_satisfied` helper to check if a section already has a value in the config, supporting the new filtering logic.

### Integration into settings UI

* Updated `get_relevant_settings` in `settings.py` to use `filter_visible_sections`, ensuring the UI only shows relevant and unsatisfied sections per the new logic. [[1]](diffhunk://#diff-6269baaad21d2a42b272d2c2438703ae4c8206c44f7ec96db24fa041aceec5fdL31-R31) [[2]](diffhunk://#diff-6269baaad21d2a42b272d2c2438703ae4c8206c44f7ec96db24fa041aceec5fdR282-R287)

### Setup workflow refactoring

* Refined the `CHECKBOX_TO_SECTIONS` mapping in `section_registry.py` to clarify the distinction between preparation steps and the main setup steps, and to ensure consistency with the sidebar order. [[1]](diffhunk://#diff-0a5b1e4b6883fe8d49d925a9f227509e1bd877efd4095a616693065540bc70c4R11-R42) [[2]](diffhunk://#diff-0a5b1e4b6883fe8d49d925a9f227509e1bd877efd4095a616693065540bc70c4L35-L46)
* Adjusted the sidebar order in `setup.py` to match the new setup step order, moving "Rig" after "Facies" for improved logical flow. [[1]](diffhunk://#diff-cd4db17dfdf9799373c820d55d80e9573e34276c4faca9e4c19e737075304b3eL176) [[2]](diffhunk://#diff-cd4db17dfdf9799373c820d55d80e9573e34276c4faca9e4c19e737075304b3eR194)