### PR TITLE
Remove class RoiAndSubroi*

### DIFF
--- a/src/darsia/presets/workflows/comparison/comparison_wasserstein.py
+++ b/src/darsia/presets/workflows/comparison/comparison_wasserstein.py
@@ -508,26 +508,6 @@ def _compute_wasserstein_distances(
                                 / roi_integral_average,
                             }
 
-                            # Control evaluation of the transport density over sub-rois
-                            # weighted_transport_density = darsia.full_like(
-                            #    roi_mass_1,
-                            #    info.get("weighted_transport_density"),
-                            # )
-                            # transport_density.show()
-                            # for sub_roi_name in roi_config.sub_roi:
-                            #    sub_roi_config = config.wasserstein.sub_roi[sub_roi_name]
-                            # subroi_distance = _evaluate_single_wasserstein_roi(
-                            #    distance,
-                            #    info,
-                            #    sub_roi_name,
-                            #    sub_roi_config,
-                            #    results_dir,
-                            #    skip_existing,
-                            # )
-
-                            # sub_roi_result = None
-                            # ...
-
                             computation_time = time_.time() - start_time
 
                         # Create and save result

--- a/src/darsia/presets/workflows/config/roi.py
+++ b/src/darsia/presets/workflows/config/roi.py
@@ -78,17 +78,3 @@ class MultiRoiConfig:
 
 RoiAndLabelConfig = RoiConfig
 """Deprecated alias for RoiConfig. Kept for backward compatibility."""
-
-
-@dataclass
-class RoiAndSubroiConfig(RoiConfig):
-    """Configuration for an ROI with a sub-ROI (inherits optional label from RoiConfig)."""
-
-    subroi_config: RoiConfig = field(default_factory=RoiConfig)
-    """Sub-ROI configuration."""
-
-    def load(self, sec: dict) -> "RoiAndSubroiConfig":
-        super().load(sec)
-        subroi_sec = _get_section(sec, "subroi")
-        self.subroi_config = RoiConfig().load(subroi_sec)
-        return self

--- a/src/darsia/presets/workflows/config/roi_registry.py
+++ b/src/darsia/presets/workflows/config/roi_registry.py
@@ -5,7 +5,7 @@ import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from .roi import RoiAndSubroiConfig, RoiConfig
+from .roi import RoiConfig
 from .utils import _convert_none
 
 logger = logging.getLogger(__name__)
@@ -85,9 +85,7 @@ def _load_roi_key_list(
 class RoiRegistry:
     """A registry of named ROI entries loaded from a top-level [[roi]] TOML array-of-tables.
 
-    Entries are auto-typed on load:
-    - If the entry has a ``subroi`` sub-section → :class:`RoiAndSubroiConfig`.
-    - Otherwise → :class:`RoiConfig` (with optional ``label`` field).
+    Entries are loaded as :class:`RoiConfig` (with optional ``label`` field).
     """
 
     rois: dict[str, RoiConfig] = field(
@@ -153,14 +151,11 @@ class RoiRegistry:
                     )
                 seen_names.add(name)
 
-                if "subroi" in entry:
-                    self.rois[name] = RoiAndSubroiConfig().load(entry)
-                else:
-                    self.rois[name] = RoiConfig().load(entry)
+                self.rois[name] = RoiConfig().load(entry)
 
         return self
 
-    def register(self, key: str, roi: "RoiConfig | RoiAndSubroiConfig") -> None:
+    def register(self, key: str, roi: RoiConfig) -> None:
         """Add a single ROI entry to the registry without overwriting existing entries.
 
         This is useful when inline ROI definitions (e.g. from a
@@ -187,7 +182,7 @@ class RoiRegistry:
 
     def resolve(
         self, keys: str | list[str]
-    ) -> dict[str, RoiConfig | RoiAndSubroiConfig]:
+    ) -> dict[str, RoiConfig]:
         """Return a dict of the requested entries keyed by their registry name.
 
         Args:
@@ -218,8 +213,8 @@ class RoiRegistry:
             keys: A single key string or a list of key strings.
 
         Returns:
-            Dict containing only the entries with ``label is None`` (plain RoiConfig
-            instances or RoiAndSubroiConfig with no label, but not label-restricted entries).
+            Dict containing only the entries with ``label is None``, i.e. not
+            label-restricted entries.
         """
         resolved = self.resolve(keys)
         return {

--- a/src/darsia/presets/workflows/config/roi_registry.py
+++ b/src/darsia/presets/workflows/config/roi_registry.py
@@ -180,9 +180,7 @@ class RoiRegistry:
         """Return all registered key names."""
         return list(self.rois.keys())
 
-    def resolve(
-        self, keys: str | list[str]
-    ) -> dict[str, RoiConfig]:
+    def resolve(self, keys: str | list[str]) -> dict[str, RoiConfig]:
         """Return a dict of the requested entries keyed by their registry name.
 
         Args:


### PR DESCRIPTION
Class had not been used in the new GUI and workflows. Seemed to hardcoded anyways.