### PR TITLE
Window image

### DIFF
--- a/src/darsia/gui/ui/image_canvas.py
+++ b/src/darsia/gui/ui/image_canvas.py
@@ -1,0 +1,54 @@
+"""Generic scale-to-fit image display widget for the DarSIA GUI."""
+
+from pathlib import Path
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QPixmap
+from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
+
+
+class ImageCanvas(QWidget):
+    """Load-from-path, scale-to-fit, keep-aspect-ratio image display, with a
+    plain-text placeholder state for "nothing to show yet"."""
+
+    def __init__(self, placeholder_text: str = ""):
+        super().__init__()
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        self._label = QLabel(placeholder_text)
+        self._label.setAlignment(Qt.AlignCenter)
+        self._label.setWordWrap(True)
+        self._label.setMinimumSize(150, 150)
+        layout.addWidget(self._label, stretch=1)
+        self._original_pixmap: QPixmap | None = None
+
+    def set_image_path(self, path: Path | None) -> None:
+        """Display the image at path, or clear to an empty state if None."""
+        if path is None:
+            self.set_message("")
+            return
+        pixmap = QPixmap(str(path))
+        if pixmap.isNull():
+            self.set_message(f"Could not load image:\n{path}")
+            return
+        self._original_pixmap = pixmap
+        self._rescale()
+
+    def set_message(self, text: str) -> None:
+        """Clear any image and show a plain-text placeholder/status message."""
+        self._original_pixmap = None
+        self._label.setPixmap(QPixmap())
+        self._label.setText(text)
+
+    def _rescale(self) -> None:
+        if self._original_pixmap is None:
+            return
+        self._label.setPixmap(
+            self._original_pixmap.scaled(
+                self._label.size(), Qt.KeepAspectRatio, Qt.SmoothTransformation
+            )
+        )
+
+    def resizeEvent(self, event) -> None:
+        super().resizeEvent(event)
+        self._rescale()

--- a/src/darsia/gui/ui/main_window.py
+++ b/src/darsia/gui/ui/main_window.py
@@ -67,6 +67,7 @@ class MainWindow(QMainWindow):
     _SIDEBAR_WIDTH_SETTINGS_KEY = "ui/sidebar_width"
     _DEFAULT_SIDEBAR_WIDTH = 120
     _LOG_VISIBLE_SETTINGS_KEY = "ui/log_visible"
+    _VIEW_VISIBLE_SETTINGS_KEY = "ui/view_visible"
 
     def __init__(self):
         super().__init__()
@@ -103,19 +104,23 @@ class MainWindow(QMainWindow):
         # Initialize process runner
         self.process_runner = ProcessRunner(self)
 
-        # Streaming preview dock (right of the tabs), created before the menu
+        # View dock (right of the tabs): streaming preview + on-disk results
+        # browsing (StreamingPanel's two modes). Created before the menu
         # builder since it wires a View-menu toggle action for this dock.
         self.streaming_panel = StreamingPanel(self)
-        self.streaming_dock = QDockWidget("Streaming Preview", self)
+        self.streaming_dock = QDockWidget("View", self)
         self.streaming_dock.setWidget(self.streaming_panel)
         # Closable only: no float/drag, so the fixed edge-toggle button (see
         # below) always points at where the panel actually is.
         self.streaming_dock.setFeatures(QDockWidget.DockWidgetClosable)
         self.addDockWidget(Qt.RightDockWidgetArea, self.streaming_dock)
-        self.streaming_dock.hide()
+        view_visible = QSettings().value(
+            self._VIEW_VISIBLE_SETTINGS_KEY, True, type=bool
+        )
+        self.streaming_dock.setVisible(view_visible)
 
         # Logging dock (bottom), created before the menu builder for the same
-        # reason as Streaming Preview: it wires a View-menu toggle action.
+        # reason as the View dock: it wires a View-menu toggle action.
         log_container = QWidget()
         log_layout = QVBoxLayout(log_container)
         log_layout.addWidget(QLabel("Logging:"))
@@ -267,7 +272,7 @@ class MainWindow(QMainWindow):
 
         main_layout.addWidget(left_column, 1)
 
-        # Thin edge handle to reveal/hide the Streaming Preview dock, sitting
+        # Thin edge handle to reveal/hide the View dock, sitting
         # at the boundary between the main content and the (right-docked,
         # now closable-only) dock, spanning the full window height. Drives
         # the same toggleViewAction as Ctrl+P/View menu/toolbar, so all four
@@ -303,10 +308,9 @@ class MainWindow(QMainWindow):
         toolbar, this button, or the dock's own close button)."""
         self.streaming_toggle_button.setText(">" if visible else "<")
         self.streaming_toggle_button.setToolTip(
-            "Hide Streaming Preview (Ctrl+P)"
-            if visible
-            else "Show Streaming Preview (Ctrl+P)"
+            "Hide View (Ctrl+P)" if visible else "Show View (Ctrl+P)"
         )
+        QSettings().setValue(self._VIEW_VISIBLE_SETTINGS_KEY, visible)
 
     def _refresh_streaming_toggle_style(self):
         """Rebuild the edge-toggle button's palette-aware styling (theme-safe)."""
@@ -473,6 +477,7 @@ class MainWindow(QMainWindow):
         self.selected_action = action
         self.selected_checkbox_id = checkbox_id
         self.settings_factory.display_settings(action, [checkbox_id])
+        self.streaming_panel.refresh_results()
 
     def _on_open_full_config(self):
         """Handle opening full config: deselect sidebar and show all settings."""
@@ -484,6 +489,14 @@ class MainWindow(QMainWindow):
     # aren't a mechanical underscore-to-space rename of the checkbox_id
     # (e.g. Calibration's "color" step is labeled "color embedding" there).
     _PROGRESS_ACTION_LABEL_OVERRIDES = {("calibration", "color"): "color embedding"}
+
+    def action_label_for(self, category: str, checkbox_id: str) -> str:
+        """Map a (category, checkbox_id) pair to the action-label string
+        results_folder.py's resolvers expect (see _PROGRESS_ACTION_LABEL_OVERRIDES
+        docstring above for why most are a mechanical rename)."""
+        return self._PROGRESS_ACTION_LABEL_OVERRIDES.get(
+            (category, checkbox_id), checkbox_id.replace("_", " ")
+        )
 
     def refresh_sidebar_progress(self):
         """Update sidebar completion dots from on-disk workflow output.
@@ -509,13 +522,12 @@ class MainWindow(QMainWindow):
         for category, tab_manager in tab_managers.items():
             for _group_label, items in tab_manager.sidebar_items():
                 for _label, checkbox_id, _icon, _help in items:
-                    action_label = self._PROGRESS_ACTION_LABEL_OVERRIDES.get(
-                        (category, checkbox_id), checkbox_id.replace("_", " ")
-                    )
+                    action_label = self.action_label_for(category, checkbox_id)
                     done = has_workflow_output(category, config_path, [action_label])
                     self.sidebar.set_item_state(
                         category, checkbox_id, "done" if done else "none"
                     )
+        self.streaming_panel.refresh_results()
 
     def run_selected_workflow(self):
         """Run the currently selected sidebar workflow (Play button / Ctrl+Return)."""

--- a/src/darsia/gui/ui/menu.py
+++ b/src/darsia/gui/ui/menu.py
@@ -96,18 +96,18 @@ class MenuBuilder:
             theme_group.addAction(action)
 
         # Logging dock's built-in toggle action (checkable, tracks the dock's
-        # shown/hidden state automatically) — same pattern as Streaming Preview.
+        # shown/hidden state automatically) — same pattern as the View dock.
         self.show_logging_action = self.main_window.log_dock.toggleViewAction()
         self.show_logging_action.setText("Show &Logging")
         self.show_logging_action.setShortcut(QKeySequence("Ctrl+L"))
         view_menu.addAction(self.show_logging_action)
 
-        # Streaming Preview dock's built-in toggle action (checkable, tracks
-        # the dock's shown/hidden state automatically).
+        # View dock's built-in toggle action (checkable, tracks the dock's
+        # shown/hidden state automatically).
         self.streaming_toggle_action = (
             self.main_window.streaming_dock.toggleViewAction()
         )
-        self.streaming_toggle_action.setText("Show &Streaming Preview")
+        self.streaming_toggle_action.setText("Show &View")
         self.streaming_toggle_action.setShortcut(QKeySequence("Ctrl+P"))
         view_menu.addAction(self.streaming_toggle_action)
 

--- a/src/darsia/gui/ui/streaming.py
+++ b/src/darsia/gui/ui/streaming.py
@@ -6,15 +6,13 @@ mode_selector:
 - Streaming mode displays the low-resolution preview images an Analysis run
   publishes while "Stream preview" is enabled (options.analysis.stream_preview),
   as a scrubbable timeline: one entry per processed image, sorted by its real
-  imaging-protocol timestamp (not by arrival order, since
-  options.analysis.random_traverse can process images out of chronological
-  order). The workflow subprocess writes each preview frame to a per-run
-  cache directory (one PNG file per (stream key, sequence number), never
-  overwritten) and prints two tiny stdout notification lines per image: a
-  stream line naming which keys were just written, tagged with a sequence
-  number, and a progress line carrying that same sequence number alongside
-  the image's real index/datetime. This panel correlates the two by that
-  shared sequence number. See darsia.presets.workflows.analysis.streaming
+  imaging-protocol timestamp. The workflow subprocess writes each preview
+  frame to a per-run cache directory (one PNG file per (stream key, sequence
+  number), never overwritten) and prints two tiny stdout notification lines
+  per image: a stream line naming which keys were just written, tagged with
+  a sequence number, and a progress line carrying that same sequence number
+  alongside the image's real index/datetime. This panel correlates the two
+  by that shared sequence number. See darsia.presets.workflows.analysis.streaming
   and darsia.presets.workflows.analysis.progress for the producer side.
   Entering this mode is triggered automatically when a run starts with
   Stream preview enabled (reset_for_run); the user can still switch back to

--- a/src/darsia/gui/ui/streaming.py
+++ b/src/darsia/gui/ui/streaming.py
@@ -1,20 +1,29 @@
-"""Streaming preview panel for the DarSIA GUI.
+"""View panel for the DarSIA GUI: streaming preview and results browsing.
 
-Displays the low-resolution preview images an Analysis run publishes while
-"Stream preview" is enabled (options.analysis.stream_preview), as a
-scrubbable timeline: one entry per processed image, sorted by its real
-imaging-protocol timestamp (not by arrival order, since
-options.analysis.random_traverse can process images out of chronological
-order).
+Two modes share one image display/slider/status trio, switched via
+mode_selector:
 
-The workflow subprocess writes each preview frame to a per-run cache
-directory (one PNG file per (stream key, sequence number), never
-overwritten) and prints two tiny stdout notification lines per image: a
-stream line naming which keys were just written, tagged with a sequence
-number, and a progress line carrying that same sequence number alongside the
-image's real index/datetime. This panel correlates the two by that shared
-sequence number. See darsia.presets.workflows.analysis.streaming and
-darsia.presets.workflows.analysis.progress for the producer side.
+- Streaming mode displays the low-resolution preview images an Analysis run
+  publishes while "Stream preview" is enabled (options.analysis.stream_preview),
+  as a scrubbable timeline: one entry per processed image, sorted by its real
+  imaging-protocol timestamp (not by arrival order, since
+  options.analysis.random_traverse can process images out of chronological
+  order). The workflow subprocess writes each preview frame to a per-run
+  cache directory (one PNG file per (stream key, sequence number), never
+  overwritten) and prints two tiny stdout notification lines per image: a
+  stream line naming which keys were just written, tagged with a sequence
+  number, and a progress line carrying that same sequence number alongside
+  the image's real index/datetime. This panel correlates the two by that
+  shared sequence number. See darsia.presets.workflows.analysis.streaming
+  and darsia.presets.workflows.analysis.progress for the producer side.
+  Entering this mode is triggered automatically when a run starts with
+  Stream preview enabled (reset_for_run); the user can still switch back to
+  Results mode at any time, including mid-run.
+
+- Results mode browses every on-disk output image for whichever sidebar
+  step is currently selected (results_folder.list_workflow_output_images),
+  refreshed whenever the sidebar selection changes or a run completes (see
+  refresh_results, called from main_window.py).
 """
 
 import bisect
@@ -24,7 +33,6 @@ from datetime import datetime
 from pathlib import Path
 
 from PySide6.QtCore import Qt
-from PySide6.QtGui import QPixmap
 from PySide6.QtWidgets import (
     QComboBox,
     QHBoxLayout,
@@ -37,20 +45,46 @@ from PySide6.QtWidgets import (
 
 from darsia.presets.workflows.analysis.progress import try_decode_progress_line
 from darsia.presets.workflows.analysis.streaming import try_decode_stream_notify_line
+from darsia.presets.workflows.results_folder import list_workflow_output_images
+
+from .image_canvas import ImageCanvas
+
+_NO_SELECTION_TEXT = "Select a step to see its results."
+_NO_IMAGE_TEXT = "No image output yet for this step."
+_NO_CONFIG_TEXT = "Load a config to see step output."
 
 
 class StreamingPanel(QWidget):
-    """Live/scrubbable viewer for streamed Analysis preview images."""
+    """View panel: live/scrubbable streamed preview, or on-disk results browsing."""
 
     def __init__(self, main_window):
         super().__init__()
         self.main_window = main_window
+        self._mode = "results"
+
+        # Streaming-mode state.
         self._cache_dir: Path | None = None
         self._pending_seq_keys: dict[int, list[str]] = {}
         self._timeline: list[dict] = []  # sorted by "datetime" (None sorts last)
         self._auto_follow = True
+        self._streaming_index = 0
+
+        # Results-mode state.
+        self._results_images: list[Path] = []
+        self._results_index = 0
 
         layout = QVBoxLayout(self)
+
+        # Built and defaulted to "Results" before the signal is connected
+        # (below, once the rest of the widgets exist): its handler calls
+        # refresh_results(), which reads main_window state not yet set up
+        # this early in MainWindow.__init__.
+        self.mode_selector = QComboBox()
+        self.mode_selector.addItems(["Streaming", "Results"])
+        self.mode_selector.blockSignals(True)
+        self.mode_selector.setCurrentText("Results")
+        self.mode_selector.blockSignals(False)
+        layout.addWidget(self.mode_selector)
 
         self.status_label = QLabel("Streaming disabled.")
         layout.addWidget(self.status_label)
@@ -59,10 +93,8 @@ class StreamingPanel(QWidget):
         self.key_selector.currentTextChanged.connect(self._on_key_changed)
         layout.addWidget(self.key_selector)
 
-        self.image_label = QLabel("No streamed image.")
-        self.image_label.setAlignment(Qt.AlignCenter)
-        self.image_label.setMinimumSize(200, 200)
-        layout.addWidget(self.image_label, stretch=1)
+        self.image_canvas = ImageCanvas(placeholder_text=_NO_SELECTION_TEXT)
+        layout.addWidget(self.image_canvas, stretch=1)
 
         self.timeline_label = QLabel("")
         layout.addWidget(self.timeline_label)
@@ -81,6 +113,100 @@ class StreamingPanel(QWidget):
         slider_row.addWidget(self.jump_to_latest_button)
         layout.addLayout(slider_row)
 
+        self.key_selector.setVisible(False)
+        self._show_message(_NO_SELECTION_TEXT)
+
+        # Connected only now that every widget _apply_mode/refresh_results
+        # touches exists (see the comment by mode_selector's construction).
+        self.mode_selector.currentTextChanged.connect(
+            lambda text: self._apply_mode(text.lower())
+        )
+
+    # ------------------------------------------------------------------
+    # Mode switching
+    # ------------------------------------------------------------------
+
+    def _apply_mode(self, mode: str) -> None:
+        self._mode = mode
+        self.key_selector.setVisible(mode == "streaming")
+        if mode == "streaming":
+            self.slider.blockSignals(True)
+            self.slider.setRange(0, max(0, len(self._timeline) - 1))
+            index = (
+                len(self._timeline) - 1 if self._auto_follow else self._streaming_index
+            )
+            index = max(0, index)
+            self.slider.setValue(index)
+            self.slider.setEnabled(bool(self._timeline))
+            self.slider.blockSignals(False)
+            self.jump_to_latest_button.setEnabled(
+                bool(self._timeline) and not self._auto_follow
+            )
+            if self._timeline:
+                self._render_streaming_position(index)
+            else:
+                self._show_message("Streaming disabled.")
+        else:
+            self.refresh_results()
+
+    # ------------------------------------------------------------------
+    # Results mode
+    # ------------------------------------------------------------------
+
+    def refresh_results(self) -> None:
+        """Re-resolve on-disk output images for the current sidebar
+        selection. Call on sidebar selection change and after
+        refresh_sidebar_progress() (covers initial load, config reload, and
+        post-run completion, since all three already call it). Rescans
+        disk unconditionally, but only touches the shared display widgets
+        when Results mode is currently active."""
+        mw = self.main_window
+        action, checkbox_id = mw.selected_action, mw.selected_checkbox_id
+        if action is None or checkbox_id is None:
+            self._results_images = []
+            if self._mode == "results":
+                self._show_message(_NO_SELECTION_TEXT)
+            return
+        if not mw.config_file or not Path(mw.config_file).exists():
+            self._results_images = []
+            if self._mode == "results":
+                self._show_message(_NO_CONFIG_TEXT)
+            return
+        action_label = mw.action_label_for(action, checkbox_id)
+        try:
+            self._results_images = list_workflow_output_images(
+                action, Path(mw.config_file), [action_label]
+            )
+        except Exception:
+            self._results_images = []
+        self._results_index = max(0, len(self._results_images) - 1)
+        if self._mode != "results":
+            return
+        self.slider.blockSignals(True)
+        self.slider.setRange(0, max(0, len(self._results_images) - 1))
+        self.slider.setValue(self._results_index)
+        self.slider.setEnabled(bool(self._results_images))
+        self.slider.blockSignals(False)
+        self.jump_to_latest_button.setEnabled(False)
+        if self._results_images:
+            self._render_results_position(self._results_index)
+        else:
+            self._show_message(_NO_IMAGE_TEXT)
+
+    def _render_results_position(self, index: int) -> None:
+        if not self._results_images or not (0 <= index < len(self._results_images)):
+            self._show_message(_NO_IMAGE_TEXT)
+            return
+        path = self._results_images[index]
+        self.image_canvas.set_image_path(path)
+        self.timeline_label.setText(f"{index + 1} / {len(self._results_images)}")
+        self.timeline_label.setToolTip(str(path))
+        self.status_label.setText(f"Showing results for: {path.name}")
+
+    # ------------------------------------------------------------------
+    # Streaming mode
+    # ------------------------------------------------------------------
+
     def prepare_cache_dir(self) -> Path:
         """Free any previous run's cache dir and create a fresh one."""
         if self._cache_dir is not None:
@@ -94,6 +220,7 @@ class StreamingPanel(QWidget):
         self._pending_seq_keys = {}
         self._timeline = []
         self._auto_follow = True
+        self._streaming_index = 0
         self.key_selector.clear()
         self.slider.blockSignals(True)
         self.slider.setRange(0, 0)
@@ -103,8 +230,12 @@ class StreamingPanel(QWidget):
         self.jump_to_latest_button.setEnabled(False)
         self.timeline_label.setText("")
         if enabled:
+            self.mode_selector.blockSignals(True)
+            self.mode_selector.setCurrentText("Streaming")
+            self.mode_selector.blockSignals(False)
+            self._apply_mode("streaming")
             self._show_message("Streaming enabled. Waiting for data...")
-        else:
+        elif self._mode == "streaming":
             self._show_message("Streaming disabled.")
 
     def handle_stream_line(self, line: str) -> None:
@@ -112,7 +243,8 @@ class StreamingPanel(QWidget):
         try:
             is_stream_line, decoded = try_decode_stream_notify_line(line)
         except Exception:
-            self._show_message("Stream error.")
+            if self._mode == "streaming":
+                self._show_message("Stream error.")
             return
         if not is_stream_line:
             return
@@ -167,7 +299,9 @@ class StreamingPanel(QWidget):
         self._timeline.insert(position, entry)
 
         # Refresh the key dropdown with the union of keys seen so far,
-        # preserving the current selection if still valid.
+        # preserving the current selection if still valid. Kept up to date
+        # unconditionally (cheap, and hidden while not in Streaming mode)
+        # so switching back to Streaming mode later shows current data.
         current_key = self.key_selector.currentText()
         all_keys = sorted({k for e in self._timeline for k in e["keys"]})
         shown_keys = [
@@ -181,6 +315,9 @@ class StreamingPanel(QWidget):
                 self.key_selector.setCurrentText(current_key)
             self.key_selector.blockSignals(False)
 
+        if self._mode != "streaming":
+            return
+
         self.slider.blockSignals(True)
         self.slider.setRange(0, len(self._timeline) - 1)
         self.slider.setEnabled(True)
@@ -193,29 +330,44 @@ class StreamingPanel(QWidget):
             self.jump_to_latest_button.setEnabled(True)
 
     def _on_user_scrub_start(self) -> None:
+        if self._mode != "streaming":
+            return
         self._auto_follow = False
         self.jump_to_latest_button.setEnabled(True)
 
     def _on_slider_moved(self, value: int) -> None:
-        self._render_position(value)
+        if self._mode == "streaming":
+            self._streaming_index = value
+            self._render_streaming_position(value)
+        else:
+            self._results_index = value
+            self._render_results_position(value)
 
     def _jump_to_latest(self) -> None:
-        self._auto_follow = True
-        self.jump_to_latest_button.setEnabled(False)
-        if self._timeline:
-            self._set_slider_position(len(self._timeline) - 1)
+        if self._mode == "streaming":
+            self._auto_follow = True
+            self.jump_to_latest_button.setEnabled(False)
+            if self._timeline:
+                self._set_slider_position(len(self._timeline) - 1)
+        else:
+            if self._results_images:
+                self._results_index = len(self._results_images) - 1
+                self._set_slider_position(self._results_index)
 
     def _set_slider_position(self, index: int) -> None:
         self.slider.blockSignals(True)
         self.slider.setValue(index)
         self.slider.blockSignals(False)
-        self._render_position(index)
+        if self._mode == "streaming":
+            self._render_streaming_position(index)
+        else:
+            self._render_results_position(index)
 
     def _on_key_changed(self, key: str) -> None:
-        if key:
-            self._render_position(self.slider.value())
+        if key and self._mode == "streaming":
+            self._render_streaming_position(self.slider.value())
 
-    def _render_position(self, index: int) -> None:
+    def _render_streaming_position(self, index: int) -> None:
         if not self._timeline or not (0 <= index < len(self._timeline)):
             self._show_message("Nothing is streamed.")
             return
@@ -225,28 +377,18 @@ class StreamingPanel(QWidget):
             self._show_message("Nothing is streamed.")
             return
         path = self._cache_dir / key / f"{entry['seq']}.png"
-        pixmap = QPixmap(str(path))
-        if pixmap.isNull():
-            self._show_message("Stream error.")
-            return
-        self.image_label.setPixmap(
-            pixmap.scaled(
-                self.image_label.size(),
-                Qt.KeepAspectRatio,
-                Qt.SmoothTransformation,
-            )
-        )
+        self.image_canvas.set_image_path(path)
         when = (
             entry["datetime"].strftime("%Y-%m-%d %H:%M:%S")
             if entry["datetime"]
             else "unknown time"
         )
         self.timeline_label.setText(f"{index + 1} / {len(self._timeline)} — {when}")
+        self.timeline_label.setToolTip(str(path))
         self.status_label.setText(f"Showing stream key: {key}")
 
     def _show_message(self, message: str) -> None:
-        self.image_label.setText(message)
-        self.image_label.setPixmap(QPixmap())
+        self.image_canvas.set_message(message)
         self.status_label.setText(message)
 
     def cleanup(self) -> None:

--- a/src/darsia/gui/ui/toolbar.py
+++ b/src/darsia/gui/ui/toolbar.py
@@ -75,7 +75,7 @@ class ToolbarBuilder:
         self._configure(
             self.menu_builder.streaming_toggle_action,
             "stream",
-            "Toggle Streaming Preview (Ctrl+P)",
+            "Toggle View (Ctrl+P)",
         )
         toolbar.addAction(self.menu_builder.streaming_toggle_action)
 

--- a/src/darsia/presets/workflows/config/options.py
+++ b/src/darsia/presets/workflows/config/options.py
@@ -68,10 +68,7 @@ class AnalysisOptions:
         default=False,
         metadata={
             "name": "Stream preview",
-            "help": (
-                "Publish low-res preview images during analysis for the "
-                "Streaming Preview panel."
-            ),
+            "help": "Publish low-res preview images during analysis for the View panel.",
         },
     )
 

--- a/src/darsia/presets/workflows/results_folder.py
+++ b/src/darsia/presets/workflows/results_folder.py
@@ -189,6 +189,51 @@ def has_workflow_output(workflow: str, config_path: Path, actions: list[str]) ->
         return False
 
 
+_IMAGE_SUFFIXES = {".png", ".jpg", ".jpeg"}
+
+
+def _resolve_output_images(
+    workflow: str, config_path: Path, actions: list[str]
+) -> list[Path]:
+    """Return every image file under the resolved results folder for this
+    workflow step, in arbitrary order, or [] if no folder resolves, the
+    folder does not exist yet, or it contains no image file.
+
+    Recursively globs for an image rather than encoding each step's own
+    subfolder convention: those conventions vary a lot across steps (flat,
+    mode/fmt/stem, fmt/layer/stem, nested plot-kind trees) and shift
+    whenever a workflow's export logic changes, so this stays
+    low-maintenance at the cost of not knowing which image variant it
+    picked among several a step might produce.
+    """
+    try:
+        folder = suggested_workflow_results_folder(workflow, config_path, actions)
+    except (OSError, ValueError, tomllib.TOMLDecodeError):
+        return []
+    if folder is None:
+        return []
+    try:
+        if not folder.exists():
+            return []
+        return [
+            path
+            for path in folder.rglob("*")
+            if path.is_file() and path.suffix.lower() in _IMAGE_SUFFIXES
+        ]
+    except OSError:
+        return []
+
+
+def list_workflow_output_images(
+    workflow: str, config_path: Path, actions: list[str]
+) -> list[Path]:
+    """Return every image file for this workflow step, sorted by filename.
+    Drives the GUI's View panel's Results-mode browsing.
+    """
+    images = _resolve_output_images(workflow, config_path, actions)
+    return sorted(images, key=lambda path: path.name)
+
+
 def open_in_file_explorer(path: Path) -> None:
     """Open path in the OS file explorer."""
     target = path.expanduser().resolve()

--- a/src/darsia/presets/workflows/results_folder.py
+++ b/src/darsia/presets/workflows/results_folder.py
@@ -143,7 +143,22 @@ def suggested_workflow_results_folder(
                 return _color_path_embedding_root(merged, results, embedding_id.strip())
             return None
         if "mass" in selected_actions or "default mass" in selected_actions:
-            return results / "calibration"
+            calibration = merged.get("calibration")
+            mass_section = (
+                calibration.get("mass") if isinstance(calibration, dict) else None
+            )
+            embedding_id = (
+                mass_section.get("embedding")
+                if isinstance(mass_section, dict)
+                else None
+            )
+            if isinstance(embedding_id, str) and embedding_id.strip():
+                return (
+                    _color_path_embedding_root(merged, results, embedding_id.strip())
+                    / "interpolation"
+                    / "mass"
+                )
+            return None
         return None
 
     if workflow == "comparison":

--- a/src/darsia/presets/workflows/results_folder.py
+++ b/src/darsia/presets/workflows/results_folder.py
@@ -75,6 +75,26 @@ def suggested_analysis_results_folder(
     return results / _ANALYSIS_MODE_DEFAULT_SUBFOLDER[mode]
 
 
+def _color_path_embedding_root(
+    merged: dict[str, Any], results: Path, embedding_id: str
+) -> Path:
+    """Resolve a [[color_path]] embedding's root folder from merged config.
+
+    Mirrors parse_color_path_embedding's own default
+    (<results>/color/color_path/<embedding_id>), honoring an explicit
+    per-entry `root =` override the same way that function does.
+    """
+    color_path_entries = merged.get("color_path")
+    if isinstance(color_path_entries, list):
+        for entry in color_path_entries:
+            if isinstance(entry, dict) and entry.get("name") == embedding_id:
+                root_raw = entry.get("root")
+                if isinstance(root_raw, str) and root_raw.strip():
+                    return Path(root_raw).expanduser()
+                break
+    return results / "color" / "color_path" / embedding_id
+
+
 def suggested_workflow_results_folder(
     workflow: str, config_path: Path, actions: list[str]
 ) -> Path | None:
@@ -109,11 +129,20 @@ def suggested_workflow_results_folder(
         return setup_candidates[0] if all_setup_same else results / "setup"
 
     if workflow == "calibration":
-        if (
-            "color embedding" in selected_actions
-            or "mass" in selected_actions
-            or "default mass" in selected_actions
-        ):
+        if "color embedding" in selected_actions:
+            calibration = merged.get("calibration")
+            color_section = (
+                calibration.get("color") if isinstance(calibration, dict) else None
+            )
+            embedding_id = (
+                color_section.get("embedding")
+                if isinstance(color_section, dict)
+                else None
+            )
+            if isinstance(embedding_id, str) and embedding_id.strip():
+                return _color_path_embedding_root(merged, results, embedding_id.strip())
+            return None
+        if "mass" in selected_actions or "default mass" in selected_actions:
             return results / "calibration"
         return None
 

--- a/tests/unit/test_results_folder.py
+++ b/tests/unit/test_results_folder.py
@@ -72,15 +72,49 @@ def test_suggested_workflow_results_folder_setup(tmp_path: Path) -> None:
     assert folder == results / "setup" / "depth"
 
 
-def test_suggested_workflow_results_folder_calibration(tmp_path: Path) -> None:
+def test_suggested_workflow_results_folder_calibration_mass(tmp_path: Path) -> None:
     config = tmp_path / "config.toml"
     results = tmp_path / "results"
-    config.write_text(f"[data]\nresults = '{results}'\n")
+    config.write_text(
+        f"[data]\nresults = '{results}'\n\n"
+        "[[color_path]]\nname = 'color_path'\n\n"
+        "[calibration.mass]\nembedding = 'color_path'\n"
+    )
 
     folder = suggested_workflow_results_folder(
         "calibration", config, ["default mass", "show"]
     )
-    assert folder == results / "calibration"
+    assert folder == (
+        results / "color" / "color_path" / "color_path" / "interpolation" / "mass"
+    )
+
+
+def test_suggested_workflow_results_folder_calibration_mass_no_embedding(
+    tmp_path: Path,
+) -> None:
+    config = tmp_path / "config.toml"
+    results = tmp_path / "results"
+    config.write_text(f"[data]\nresults = '{results}'\n")
+
+    folder = suggested_workflow_results_folder("calibration", config, ["mass"])
+    assert folder is None
+
+
+def test_suggested_workflow_results_folder_calibration_color_embedding(
+    tmp_path: Path,
+) -> None:
+    config = tmp_path / "config.toml"
+    results = tmp_path / "results"
+    config.write_text(
+        f"[data]\nresults = '{results}'\n\n"
+        "[[color_path]]\nname = 'color_path'\n\n"
+        "[calibration.color]\nembedding = 'color_path'\n"
+    )
+
+    folder = suggested_workflow_results_folder(
+        "calibration", config, ["color embedding"]
+    )
+    assert folder == results / "color" / "color_path" / "color_path"
 
 
 def test_suggested_workflow_results_folder_comparison_events_default(


### PR DESCRIPTION
This pull request significantly refactors the DarSIA GUI's image preview panel, generalizing the previous "Streaming Preview" into a unified "View" panel that supports both live streaming and on-disk results browsing. It introduces a new `ImageCanvas` widget for image display, adds a mode selector, and ensures the panel updates its contents based on current workflow state and sidebar selection. The main window and menu are updated to reflect these changes, improving both user experience and internal code structure.

**Major UI and Feature Improvements:**

* The "Streaming Preview" dock is now called "View" and supports two modes: live streaming and results browsing, switchable via a dropdown (`mode_selector`). The panel's visibility and state persist across sessions. [[1]](diffhunk://#diff-1d5e429d3a96abcb90ca617dd45a0d8b00c90f2039e410299287ddc93261cfd3L106-R123) [[2]](diffhunk://#diff-1d5e429d3a96abcb90ca617dd45a0d8b00c90f2039e410299287ddc93261cfd3L270-R275) [[3]](diffhunk://#diff-1d5e429d3a96abcb90ca617dd45a0d8b00c90f2039e410299287ddc93261cfd3L306-R313) [[4]](diffhunk://#diff-b0ced1c428cb35f2fe1ed450be8395e566fd85e8b8fcd10af0b57bcb6914c787L99-R110) [[5]](diffhunk://#diff-d33d88c4b5747e8333cfec02224aa7767d0aab0aed27b6e94ccd2c9597e16b71L1-R26) [[6]](diffhunk://#diff-d33d88c4b5747e8333cfec02224aa7767d0aab0aed27b6e94ccd2c9597e16b71R48-R97) [[7]](diffhunk://#diff-d33d88c4b5747e8333cfec02224aa7767d0aab0aed27b6e94ccd2c9597e16b71R116-R209)
* The new `ImageCanvas` widget (`image_canvas.py`) replaces the previous QLabel-based image display, providing scale-to-fit, aspect-ratio-preserving image rendering with placeholder messages for empty states. [[1]](diffhunk://#diff-de8693288923759c6fd6a7b477528b92872b7cce3606add61d606a5e6ae3341fR1-R54) [[2]](diffhunk://#diff-d33d88c4b5747e8333cfec02224aa7767d0aab0aed27b6e94ccd2c9597e16b71R48-R97)

**Results Browsing Integration:**

* The panel can now browse on-disk output images for the currently selected sidebar step, updating automatically when the selection or config changes, or after a workflow run. Results are loaded via `list_workflow_output_images`, and relevant messages are shown if no config or selection is present. [[1]](diffhunk://#diff-d33d88c4b5747e8333cfec02224aa7767d0aab0aed27b6e94ccd2c9597e16b71R116-R209) [[2]](diffhunk://#diff-1d5e429d3a96abcb90ca617dd45a0d8b00c90f2039e410299287ddc93261cfd3R480) [[3]](diffhunk://#diff-1d5e429d3a96abcb90ca617dd45a0d8b00c90f2039e410299287ddc93261cfd3L512-R530)
* The main window provides an `action_label_for` helper to map sidebar selections to the correct action labels expected by the results resolver.

**Streaming Mode Enhancements:**

* Streaming mode is automatically activated when a run starts with streaming enabled, and the mode selector is synced accordingly. The timeline and key selection logic have been updated to support mode switching and ensure the UI reflects the latest data. [[1]](diffhunk://#diff-d33d88c4b5747e8333cfec02224aa7767d0aab0aed27b6e94ccd2c9597e16b71R223) [[2]](diffhunk://#diff-d33d88c4b5747e8333cfec02224aa7767d0aab0aed27b6e94ccd2c9597e16b71R233-R246) [[3]](diffhunk://#diff-d33d88c4b5747e8333cfec02224aa7767d0aab0aed27b6e94ccd2c9597e16b71L170-R304) [[4]](diffhunk://#diff-d33d88c4b5747e8333cfec02224aa7767d0aab0aed27b6e94ccd2c9597e16b71R318-R320)

**Codebase and Naming Consistency:**

* All references to "Streaming Preview" have been updated to "View" throughout the code and UI, improving clarity and consistency. [[1]](diffhunk://#diff-1d5e429d3a96abcb90ca617dd45a0d8b00c90f2039e410299287ddc93261cfd3L106-R123) [[2]](diffhunk://#diff-b0ced1c428cb35f2fe1ed450be8395e566fd85e8b8fcd10af0b57bcb6914c787L99-R110) [[3]](diffhunk://#diff-d33d88c4b5747e8333cfec02224aa7767d0aab0aed27b6e94ccd2c9597e16b71L1-R26) [[4]](diffhunk://#diff-d33d88c4b5747e8333cfec02224aa7767d0aab0aed27b6e94ccd2c9597e16b71R48-R97)

**References:**  
[[1]](diffhunk://#diff-de8693288923759c6fd6a7b477528b92872b7cce3606add61d606a5e6ae3341fR1-R54) [[2]](diffhunk://#diff-1d5e429d3a96abcb90ca617dd45a0d8b00c90f2039e410299287ddc93261cfd3L106-R123) [[3]](diffhunk://#diff-1d5e429d3a96abcb90ca617dd45a0d8b00c90f2039e410299287ddc93261cfd3L306-R313) [[4]](diffhunk://#diff-d33d88c4b5747e8333cfec02224aa7767d0aab0aed27b6e94ccd2c9597e16b71L1-R26) [[5]](diffhunk://#diff-d33d88c4b5747e8333cfec02224aa7767d0aab0aed27b6e94ccd2c9597e16b71R116-R209)