### PR TITLE
Save contour

### DIFF
--- a/src/darsia/gui/ui/schema/dataclass_introspection.py
+++ b/src/darsia/gui/ui/schema/dataclass_introspection.py
@@ -282,6 +282,19 @@ def _build_fields(dataclass_type: type, key_prefix: str) -> list[dict[str, Any]]
                     f"metadata['group']. Nested QGroupBoxes are not supported. "
                     f"Remove the 'group' metadata."
                 )
+
+            # Auto-wire a self-toggle checkbox: if the nested dataclass has its own
+            # field tagged section_active=True, compute active_bool_key relative to
+            # this field's storage key. Mirrors get_section_fields()'s top-level-only
+            # logic so the same pattern works at any nesting depth.
+            active_bool_key = None
+            active_bool_default = None
+            for inner_field in fields(inner_type):
+                if inner_field.metadata.get("section_active"):
+                    active_bool_key = f"{storage_key}.{inner_field.name}"
+                    active_bool_default = _field_default(inner_field)
+                    break
+
             setting_dict = {
                 "key": own_key,
                 "type": "group",
@@ -289,6 +302,8 @@ def _build_fields(dataclass_type: type, key_prefix: str) -> list[dict[str, Any]]
                 "help": field.metadata.get("help", None),
                 "link": field.metadata.get("link", None),
                 "active_list_key": field.metadata.get("active_list_key", None),
+                "active_bool_key": active_bool_key,
+                "active_bool_default": active_bool_default,
                 "loadable": field.metadata.get("loadable", None),
                 "depends_on": field.metadata.get("depends_on", None),
                 "fields": _build_fields(inner_type, storage_key),

--- a/src/darsia/gui/ui/settings.py
+++ b/src/darsia/gui/ui/settings.py
@@ -853,7 +853,29 @@ class SettingsFactory:
 
                     # Use create_setting_edit for all other fields (returns composite
                     # wrapper or group result)
-                    label_text, field_widget = self.create_setting_edit(field_schema)
+                    # Nested-group fields (e.g. Segmentation's "values"/
+                    # "contour_smoother_selection") need the entry's real saved data
+                    # injected first, same as the key_list branch above, so the group's
+                    # self-toggle checkbox and its own sub-fields prefill correctly
+                    # instead of always reading as unset/False.
+                    injected_group = (
+                        field_schema.get("type") == "group"
+                        and field_name in entry_data
+                        and entry_data[field_name] is not None
+                    )
+                    if injected_group:
+                        self.set_value(
+                            self.main_window.config_dict,
+                            field_schema["key"],
+                            entry_data[field_name],
+                        )
+                    try:
+                        label_text, field_widget = self.create_setting_edit(
+                            field_schema
+                        )
+                    finally:
+                        if injected_group:
+                            self.main_window.config_dict.pop("entry", None)
 
                     # Handle nested groups: label_text is None, field_widget is dict with
                     # "widget"
@@ -2369,8 +2391,22 @@ class SettingsFactory:
                         if isinstance(field_widget, dict) and field_widget.get(
                             "is_group_result"
                         ):
-                            # Recursively extract nested group's sub_inputs
                             nested_dict = {}
+                            # Self-toggle checkbox (active_bool_key mechanism): the bool
+                            # field driving the group's checkable title is hidden from
+                            # sub_inputs by design (see dataclass_introspection.py's
+                            # "hidden" skip), so it must be read directly off the
+                            # checkbox, same as the top-level pass does for
+                            # active_bool_key groups. Without this, checking/unchecking
+                            # such a box (e.g. Segmentation's "Activate value labels")
+                            # is silently discarded on every save.
+                            bool_key = field_widget.get("bool_key")
+                            checkbox = field_widget.get("checkbox")
+                            if bool_key and checkbox is not None:
+                                nested_dict[bool_key.rsplit(".", 1)[-1]] = (
+                                    checkbox.isChecked()
+                                )
+                            # Recursively extract nested group's sub_inputs
                             for sub_key, sub_widget in field_widget.get(
                                 "sub_inputs", {}
                             ).items():
@@ -2391,7 +2427,11 @@ class SettingsFactory:
 
                                 if isinstance(sub_unwrapped, QCheckBox):
                                     val = sub_unwrapped.isChecked()
-                                    if val is True:
+                                    # Omit only if equal to default (matches
+                                    # QComboBox/QLineEdit handling below); "only if
+                                    # True" would silently revert a default-True field
+                                    # to True whenever unchecked.
+                                    if val != bool(sub_default):
                                         nested_dict[sub_key.split(".", 1)[-1]] = val
                                 elif isinstance(sub_unwrapped, QComboBox):
                                     val = sub_unwrapped.currentText().strip()
@@ -2426,8 +2466,10 @@ class SettingsFactory:
 
                         if isinstance(unwrapped_widget, QCheckBox):
                             extracted_value = unwrapped_widget.isChecked()
-                            # Only include if True (checkbox default is usually False)
-                            should_include = extracted_value is True
+                            # Omit if equals default (matches QComboBox/QLineEdit
+                            # below); "only if True" would silently revert a
+                            # default-True field to True whenever unchecked.
+                            should_include = extracted_value != bool(field_default)
                         elif isinstance(unwrapped_widget, QComboBox):
                             text_value = unwrapped_widget.currentText().strip()
                             if text_value:

--- a/src/darsia/presets/workflows/config/analysis.py
+++ b/src/darsia/presets/workflows/config/analysis.py
@@ -539,7 +539,6 @@ class AnalysisMassConfig:
         metadata={
             "name": "Contour smoother",
             "help": "Contour smoothing algorithm.",
-            "active_list_key": "active",
         },
     )
     """Contour smoother selection and options."""

--- a/src/darsia/presets/workflows/config/contour_smoother.py
+++ b/src/darsia/presets/workflows/config/contour_smoother.py
@@ -164,6 +164,7 @@ class ContourSmootherSelection:
         metadata={
             "name": "Activate contour smoothing",
             "help": "Enable contour smoothing for extracted contours.",
+            "section_active": True,
             "hidden": True,
         },
     )

--- a/src/darsia/presets/workflows/config/fingers.py
+++ b/src/darsia/presets/workflows/config/fingers.py
@@ -83,7 +83,6 @@ class FingersConfig:
         metadata={
             "name": "Contour smoother",
             "help": "Contour smoothing algorithm.",
-            "active_list_key": "active",
         },
     )
     """Contour smoother selection and options."""

--- a/src/darsia/presets/workflows/config/segmentation.py
+++ b/src/darsia/presets/workflows/config/segmentation.py
@@ -208,7 +208,6 @@ class SegmentationConfig:
         metadata={
             "name": "Show labels",
             "help": "Optional contour value label configuration.",
-            "active_list_key": "active",
         },
     )
     """Contour value labels configuration."""
@@ -217,7 +216,6 @@ class SegmentationConfig:
         metadata={
             "name": "Contour smoother",
             "help": "Contour smoothing algorithm.",
-            "active_list_key": "active",
         },
     )
     """Contour smoother selection and options."""


### PR DESCRIPTION
This pull request improves how nested group settings with self-toggle checkboxes are handled in the settings UI, ensuring that their enabled/disabled state is correctly saved and restored at any nesting depth. It also standardizes the logic for omitting checkbox values from the config only when they match their default, preventing silent reversion of default-True fields. Additionally, the configuration dataclasses are updated to use the new mechanism, removing the now-unnecessary `active_list_key` and adding `section_active` where needed.

**Improvements to nested group self-toggle handling:**

* Added logic to `_build_fields` in `dataclass_introspection.py` to automatically detect and wire a self-toggle checkbox for nested dataclasses with a `section_active=True` field, mirroring top-level group behavior. (`[src/darsia/gui/ui/schema/dataclass_introspection.pyR285-R306](diffhunk://#diff-9a3a56645656566550fd9a2d83b6eab7259e5efb4bf4c095d10e82e52c8042a0R285-R306)`)
* In `settings.py`, ensured that when editing a nested group, the correct saved data is injected so the group's self-toggle checkbox and sub-fields are prefilled correctly, and that the checkbox state is properly extracted and saved. (`[[1]](diffhunk://#diff-6269baaad21d2a42b272d2c2438703ae4c8206c44f7ec96db24fa041aceec5fdL856-R878)`, `[[2]](diffhunk://#diff-6269baaad21d2a42b272d2c2438703ae4c8206c44f7ec96db24fa041aceec5fdL2372-R2409)`)

**Consistent handling of checkbox defaults:**

* Changed logic so that checkbox values are omitted from the config only if they match their default, instead of only including when `True`. This prevents silent loss of a default-True value when unchecked. (`[[1]](diffhunk://#diff-6269baaad21d2a42b272d2c2438703ae4c8206c44f7ec96db24fa041aceec5fdL2394-R2434)`, `[[2]](diffhunk://#diff-6269baaad21d2a42b272d2c2438703ae4c8206c44f7ec96db24fa041aceec5fdL2429-R2472)`)

**Configuration schema updates:**

* Removed `active_list_key` from relevant fields in `AnalysisMassConfig`, `FingersConfig`, and `SegmentationConfig` dataclasses, as the new mechanism supersedes it. (`[[1]](diffhunk://#diff-9e5bcb868517951123f6875d8e40cb9bfd54020ccd5362f4771fa786cdde13c6L542)`, `[[2]](diffhunk://#diff-dc7ebf22b9a3d662fb20a4283b41f4239afc0ad238538da67ffa2c0173acc4e8L86)`, `[[3]](diffhunk://#diff-913c7bef0fe34a822461cbf90b15adec220604a280a822c2943c92bf624ac912L211)`, `[[4]](diffhunk://#diff-913c7bef0fe34a822461cbf90b15adec220604a280a822c2943c92bf624ac912L220)`)
* Marked the controlling field in `ContourSmootherSelection` with `section_active=True` to enable the self-toggle mechanism. (`[src/darsia/presets/workflows/config/contour_smoother.pyR167](diffhunk://#diff-095b2aa54b090d612a49a01e6c0fa96d2b452de104afd7f2aed1c27a065a89b0R167)`)