### PR TITLE
Remove image_id, pad, and extend to folder-based blacklists

### DIFF
--- a/src/darsia/experiment/events.py
+++ b/src/darsia/experiment/events.py
@@ -22,11 +22,16 @@ def find_images_for_datetimes(
         list[darsia.Image]: List of images corresponding to the specified times.
 
     """
-    # Restrict df from imagign_interval to available image ids
+    # Restrict df from imaging_protocol to available paths
     available_paths = list(folder.glob("*"))
-    available_image_ids = {imaging_protocol.image_id(p): p for p in available_paths}
+    available_paths_by_key: dict[str, Path] = {}
+    for p in available_paths:
+        for key in imaging_protocol._candidate_protocol_paths(p):
+            if key in imaging_protocol.datetime_by_path_key:
+                available_paths_by_key[key] = p
+                break
     df = imaging_protocol.df[
-        imaging_protocol.df["image_id"].isin(available_image_ids.keys())
+        imaging_protocol.df["path"].isin(available_paths_by_key.keys())
     ]
 
     # Collect the closest images
@@ -36,8 +41,8 @@ def find_images_for_datetimes(
         closest_available_time = min(
             df["datetime"], key=lambda t: abs((t - dt).total_seconds())
         )
-        image_path = available_image_ids[
-            df[df["datetime"] == closest_available_time]["image_id"].values[0]
+        image_path = available_paths_by_key[
+            df[df["datetime"] == closest_available_time]["path"].values[0]
         ]
         closest_image_paths.append(image_path)
 

--- a/src/darsia/experiment/experiment.py
+++ b/src/darsia/experiment/experiment.py
@@ -47,15 +47,21 @@ class ProtocolledExperiment:
         imaging_protocol: Path | tuple[Path, str] | dict[Path, Path | tuple[Path, str]],
         injection_protocol: Optional[Path | tuple[Path, str]] = None,
         pressure_temperature_protocol: Optional[Path | tuple[Path, str]] = None,
-        blacklist_protocol: Optional[Path | tuple[Path, str]] = None,
-        pad: int = 5,
+        blacklist_protocol: Optional[
+            Path | tuple[Path, str] | dict[Path, Path | tuple[Path, str]]
+        ] = None,
     ):
         self.data = data
         """Pool of data paths."""
         if isinstance(imaging_protocol, dict):
+            blacklist_map = (
+                blacklist_protocol if isinstance(blacklist_protocol, dict) else {}
+            )
             self.imaging_protocol = None
             self.imaging_protocols = {
-                Path(folder): darsia.ImagingProtocol(protocol, pad, blacklist_protocol)
+                Path(folder): darsia.ImagingProtocol(
+                    protocol, blacklist_map.get(Path(folder))
+                )
                 for folder, protocol in imaging_protocol.items()
             }
             self._resolved_protocol_folders = sorted(
@@ -67,8 +73,11 @@ class ProtocolledExperiment:
                 reverse=True,
             )
         else:
+            single_blacklist = (
+                None if isinstance(blacklist_protocol, dict) else blacklist_protocol
+            )
             self.imaging_protocol = darsia.ImagingProtocol(
-                imaging_protocol, pad, blacklist_protocol
+                imaging_protocol, single_blacklist
             )
             self.imaging_protocols = None
             self._resolved_protocol_folders = []
@@ -113,7 +122,6 @@ class ProtocolledExperiment:
             injection_protocol=config.protocols.injection,
             pressure_temperature_protocol=config.protocols.pressure_temperature,
             blacklist_protocol=config.protocols.blacklist,
-            pad=config.data.pad,
         )
 
     def time_since_start(self, date: datetime) -> float:

--- a/src/darsia/experiment/protocols.py
+++ b/src/darsia/experiment/protocols.py
@@ -136,91 +136,71 @@ class ImagingProtocol:
     def __init__(
         self,
         path: Path | tuple[Path, str],
-        pad: int,
         blacklist: Optional[Path | tuple[Path, str]] = None,
     ) -> None:
         self.df = self._load_protocol(path)
         """DataFrame containing the protocol."""
-        self.pad = pad
-        """Number of digits in the image id in the file name."""
 
         if blacklist is not None:
             self.blacklist_df = self._load_blacklist(blacklist)
         else:
-            self.blacklist_df = pd.DataFrame(columns=["image_id"])
+            self.blacklist_df = pd.DataFrame(columns=["path"])
 
-        self.blacklist_ids: set[int] = set(
-            self.blacklist_df["image_id"].astype(int).tolist()
-        )
-        self.datetime_by_image_id: dict[int, datetime] = {}
-        for image_id, dt in zip(self.df["image_id"], self.df["datetime"]):
-            image_id_int = int(image_id)
-            if image_id_int not in self.datetime_by_image_id:
-                self.datetime_by_image_id[image_id_int] = dt
+        self.blacklisted_paths: set[str] = {
+            self._normalize_protocol_path(str(p))
+            for p in self.blacklist_df["path"]
+            if p is not None and not pd.isna(p)
+        }
 
         self.datetime_by_path_key: dict[str, datetime] = {}
         for protocol_path, dt in zip(self.df["path"], self.df["datetime"]):
             if protocol_path is None or pd.isna(protocol_path):
+                logger.warning("Skipping protocol row with no path: datetime %s.", dt)
                 continue
             key = self._normalize_protocol_path(str(protocol_path))
-            if key.lower() in {"nan", "none"}:
+            if key.lower() in {"nan", "none", ""}:
+                logger.warning("Skipping protocol row with no path: datetime %s.", dt)
                 continue
             if key not in self.datetime_by_path_key:
                 self.datetime_by_path_key[key] = dt
 
-    def image_id(self, path: Path) -> int:
-        """Extract image id from file name."""
-        try:
-            return int(path.stem[-self.pad :])
-        except ValueError:
-            raise ValueError(f"Invalid image id in file name: {path.stem}")
-
     def is_blacklisted(self, file_name: Path) -> bool:
-        """Check if the image is blacklisted based on the file name.
+        """Check if the image is blacklisted based on its path.
 
         Args:
-            file_name (Path): Path to the image file. The file name should end
-                with a number. If contained in a considered imaging interval,
-                the id can be correlated to a datetime.
+            file_name (Path): Path to the image file.
+
         Returns:
             bool: True if the image is blacklisted, False otherwise.
 
         """
-        if not self.blacklist_ids:
+        if not self.blacklisted_paths:
             return False
 
-        # Fetch id from input file
-        current_id = self.image_id(file_name)
-
-        return current_id in self.blacklist_ids
+        return any(
+            key in self.blacklisted_paths
+            for key in self._candidate_protocol_paths(file_name)
+        )
 
     def get_datetime(self, file_name: Path) -> Optional[datetime]:
-        """Get the datetime of the image based on the file name.
+        """Get the datetime of the image based on its path.
 
         Args:
-            file_name (Path): Path to the image file. The file name should end
-                with a number. If contained in a considered imaging interval,
-                the id can be correlated to a datetime.
+            file_name (Path): Path to the image file.
 
         Returns:
-            Optional[datetime]: The datetime of the image. None, if the file name
-                is not contained in any of the imaging intervals.
+            Optional[datetime]: The datetime of the image.
+
+        Raises:
+            ValueError: If the path is not found in the protocol.
 
         """
-        # Fetch id from input file
-        current_id = self.image_id(file_name)
-
-        # Prefer an exact path match when the protocol contains path entries.
         for key in self._candidate_protocol_paths(file_name):
             dt = self.datetime_by_path_key.get(key)
             if dt is not None:
                 return dt
 
-        # Fallback: image-id based lookup.
-        dt = self.datetime_by_image_id.get(current_id)
-        if dt is None:
-            raise ValueError(f"Image id {current_id} not found in protocol.")
-        return dt
+        raise ValueError(f"Path {file_name} not found in protocol.")
 
     @staticmethod
     def _normalize_protocol_path(path: str) -> str:
@@ -257,31 +237,21 @@ class ImagingProtocol:
         # Make all columns lowercase
         df.columns = [col.lower() for col in df.columns]
 
-        # Associate image id and time
-        # assert "path" in df.columns, "Column 'Path' not found in the protocol file."
-        assert (
-            "image_id" in df.columns
-        ), "Column 'Image_id' not found in the protocol file."
+        # Associate path and time
+        assert "path" in df.columns, "Column 'Path' not found in the protocol file."
         assert (
             "datetime" in df.columns
         ), "Column 'Datetime' not found in the protocol file."
-        if "path" in df.columns:
-            paths = (
-                df["path"]
-                .astype(str)
-                .str.replace(r"\\", "/", regex=False)
-                .str.lstrip("./")
-            )
-        else:
-            paths = [None] * len(df)
-        images = df["image_id"]
+        paths = (
+            df["path"].astype(str).str.replace(r"\\", "/", regex=False).str.lstrip("./")
+        )
         datetimes = df["datetime"]
 
         # Convert datetimes to pandas datetime objects
         datetimes = pd.to_datetime(datetimes)
 
         # Make a new dataframe object and return
-        return pd.DataFrame({"path": paths, "image_id": images, "datetime": datetimes})
+        return pd.DataFrame({"path": paths, "datetime": datetimes})
 
     def _load_blacklist(self, path: Path | tuple[Path, str]) -> pd.DataFrame:
         if isinstance(path, list) or isinstance(path, tuple):
@@ -299,13 +269,13 @@ class ImagingProtocol:
         else:
             raise ValueError("Unsupported file format. Use CSV or Excel files.")
 
-        # Expect only one column without any header
+        # Expect only one column without any header, listing image paths
         assert (
             df.shape[1] == 1
         ), "Blacklist protocol file should contain only one column."
-        df.columns = ["image_id"]
-        images = df["image_id"]
-        return pd.DataFrame({"image_id": images})
+        df.columns = ["path"]
+        paths = df["path"]
+        return pd.DataFrame({"path": paths})
 
     def find_images_for_paths(self, paths: list[Path]) -> list[Path]:
         """Find image paths for given paths.
@@ -349,15 +319,15 @@ class ImagingProtocol:
         # Remove blacklisted paths
         available_paths = self.find_images_for_paths(all_paths)
 
-        # Convert to ID.
-        available_image_ids = {}
+        # Convert to normalized protocol path keys.
+        available_paths_by_key: dict[str, Path] = {}
         for p in available_paths:
-            try:
-                available_image_ids[self.image_id(p)] = p
-            except ValueError:
-                ...
+            for key in self._candidate_protocol_paths(p):
+                if key in self.datetime_by_path_key:
+                    available_paths_by_key[key] = p
+                    break
 
-        df = self.df[self.df["image_id"].isin(available_image_ids.keys())]
+        df = self.df[self.df["path"].isin(available_paths_by_key.keys())]
 
         # Safety check.
         if df.empty:
@@ -371,13 +341,13 @@ class ImagingProtocol:
             )
             time_distance = abs((df["datetime"] - dt).dt.total_seconds())
             if tol is None:
-                closest_available_image_path = available_image_ids[
-                    df[df["datetime"] == closest_available_time]["image_id"].values[0]
+                closest_available_image_path = available_paths_by_key[
+                    df[df["datetime"] == closest_available_time]["path"].values[0]
                 ]
                 closest_available_image_paths.append(closest_available_image_path)
             elif time_distance.min() < tol:
-                closest_available_image_path = available_image_ids[
-                    df[df["datetime"] == closest_available_time]["image_id"].values[0]
+                closest_available_image_path = available_paths_by_key[
+                    df[df["datetime"] == closest_available_time]["path"].values[0]
                 ]
                 closest_available_image_paths.append(closest_available_image_path)
 
@@ -399,23 +369,21 @@ class ImagingProtocol:
             times (list[float]): List of times (in seconds) to find corresponding images for.
 
         Returns:
-            list: List of images (ids) corresponding to the specified times.
+            list: List of protocol paths corresponding to the specified times.
 
         """
         # Collect the closest images
-        image_ids = []
+        image_paths = []
 
         for dt in datetimes:
             closest_available_time = min(
                 self.df["datetime"], key=lambda t: abs((t - dt).total_seconds())
             )
-            image_id = self.df[self.df["datetime"] == closest_available_time][
-                "image_id"
-            ]
-            image_ids.append(image_id.values[0])
+            image_path = self.df[self.df["datetime"] == closest_available_time]["path"]
+            image_paths.append(image_path.values[0])
 
         # Return unique paths only but keep order
-        return list(dict.fromkeys(image_ids))
+        return list(dict.fromkeys(image_paths))
 
 
 class InjectionProtocol:

--- a/src/darsia/experiment/protocols.py
+++ b/src/darsia/experiment/protocols.py
@@ -212,10 +212,6 @@ class ImagingProtocol:
             The datetime of the image. None, if the file name
             is not contained in any of the imaging intervals.
         """
-        # Fetch id from input file
-        current_id = self.image_id(file_name)
-
-        """
         for key in self._candidate_protocol_paths(file_name):
             dt = self.datetime_by_path_key.get(key)
             if dt is not None:

--- a/src/darsia/presets/workflows/config/data.py
+++ b/src/darsia/presets/workflows/config/data.py
@@ -22,7 +22,6 @@ class DataConfig:
         # or folders = ["path/to/images_a", "path/to/images_b"]
         format = "JPG"
         baseline = "path/to/baseline.jpg"
-        pad = 0
         results = "path/to/results"
 
     """
@@ -64,11 +63,6 @@ class DataConfig:
         },
     )
     """Path to the baseline image."""
-    pad: int = field(
-        default=0,
-        metadata={"hidden": True},
-    )
-    """Pad for image names."""
     results: Path = field(
         default_factory=Path,
         metadata={
@@ -160,10 +154,6 @@ class DataConfig:
                 self.baseline = self.folder / baseline
         if require_data and not self.baseline.is_file():
             raise FileNotFoundError(f"Baseline image {self.baseline} not found.")
-
-        # Get format
-        numeric_part = "".join(filter(str.isdigit, self.baseline.stem))
-        self.pad = len(numeric_part) if numeric_part else 0
 
         # Get data
         if require_data:

--- a/src/darsia/presets/workflows/config/protocols.py
+++ b/src/darsia/presets/workflows/config/protocols.py
@@ -29,16 +29,25 @@ class ProtocolsConfig:
         },
     )
     """Per-folder mapping from data folder to imaging protocol file, or (file, sheet)."""
-    blacklist: Path | tuple[Path, str] | None = field(
-        default=None,
-        metadata={
-            "name": "Blacklist",
-            "help": "Path to a file listing images to exclude, or [file, sheet].",
-            "widget": "file",
-            "group": "Imaging",
-        },
+    blacklist: Path | tuple[Path, str] | dict[Path, Path | tuple[Path, str]] | None = (
+        field(
+            default=None,
+            metadata={
+                "name": "Blacklist",
+                "help": (
+                    "Table mapping each data folder to its blacklist file (listing "
+                    "images to exclude), or [file, sheet]. A folder with no entry "
+                    "has no blacklist. The folder column mirrors [data].folders and "
+                    "is not editable here; add or remove folders in the Data tab."
+                ),
+                "widget": "path_map",
+                "key_source": "data.folders",
+                "group": "Imaging",
+            },
+        )
     )
-    """Path to the blacklist protocol file or (file, sheet)."""
+    """Per-folder mapping from data folder to blacklist file, or (file, sheet).
+    A single bare value is also accepted for single-folder configs."""
     imaging_mode: str = field(
         default="exif",
         metadata={
@@ -112,7 +121,12 @@ class ProtocolsConfig:
 
         try:
             blacklist_protocol = sec["blacklist"]
-            if isinstance(blacklist_protocol, str) and not blacklist_protocol.strip():
+            if isinstance(blacklist_protocol, dict):
+                self.blacklist = {
+                    Path(folder): self._parse_protocol_value(protocol)
+                    for folder, protocol in blacklist_protocol.items()
+                }
+            elif isinstance(blacklist_protocol, str) and not blacklist_protocol.strip():
                 self.blacklist = None
             else:
                 self.blacklist = self._parse_protocol_value(blacklist_protocol)

--- a/src/darsia/presets/workflows/setup/setup_protocols.py
+++ b/src/darsia/presets/workflows/setup/setup_protocols.py
@@ -118,17 +118,13 @@ def preview_protocol_setup_conflicts(path: Path | list[Path]) -> list[Path]:
 
 
 def _extract_imaging_protocol_dataframe(
-    files: list[Path], pad: int, mode: str, root: Path
+    files: list[Path], mode: str, root: Path
 ) -> pd.DataFrame:
     file_paths: list[str] = []
-    file_ids: list[int] = []
     date_times: list[datetime] = []
 
     for i, filename in enumerate(files):
         logger.info("Processing file %s / %s", i + 1, len(files))
-        image_id = (
-            int(Path(filename).stem[-pad:]) if pad > 0 else int(Path(filename).stem)
-        )
         if mode == "exif":
             date_time = _extract_exif_datetime(filename)
         elif mode == "ctime":
@@ -142,7 +138,6 @@ def _extract_imaging_protocol_dataframe(
             )
             continue
         file_paths.append(filename.relative_to(root).as_posix())
-        file_ids.append(image_id)
         date_times.append(date_time)
 
     if len(date_times) == 0:
@@ -151,9 +146,7 @@ def _extract_imaging_protocol_dataframe(
             "Use [protocols].imaging_mode = 'ctime' or provide EXIF metadata."
         )
 
-    return pd.DataFrame(
-        {"path": file_paths, "image_id": file_ids, "datetime": date_times}
-    )
+    return pd.DataFrame({"path": file_paths, "datetime": date_times})
 
 
 def _write_csv(df: pd.DataFrame, path: Path) -> None:
@@ -254,9 +247,7 @@ def setup_imaging_protocol(
             raise FileNotFoundError(
                 f"No image files with suffix {suffix} found in {folder}."
             )
-        imaging_df = _extract_imaging_protocol_dataframe(
-            files, config.data.pad, mode, folder
-        )
+        imaging_df = _extract_imaging_protocol_dataframe(files, mode, folder)
         _write_csv(imaging_df, imaging_path)
         logger.info("Saved imaging protocol CSV to %s", imaging_path)
 

--- a/src/darsia/presets/workflows/setup/setup_rig.py
+++ b/src/darsia/presets/workflows/setup/setup_rig.py
@@ -69,7 +69,6 @@ def setup_rig(cls: Type[Rig], path: Path | list[Path], show: bool = False) -> No
         injection_protocol=config.protocols.injection,
         pressure_temperature_protocol=config.protocols.pressure_temperature,
         blacklist_protocol=config.protocols.blacklist,
-        pad=config.data.pad,
     )
 
     # Determine effective baseline path, using cache when enabled.

--- a/src/darsia/presets/workflows/templates/imaging_protocol.csv
+++ b/src/darsia/presets/workflows/templates/imaging_protocol.csv
@@ -1,2 +1,2 @@
-path,image_id,datetime
-baseline.JPG,0,2000-01-01 00:00:00
+path,datetime
+baseline.JPG,2000-01-01 00:00:00

--- a/tests/unit/gui/test_protocol_setup_integration.py
+++ b/tests/unit/gui/test_protocol_setup_integration.py
@@ -71,7 +71,7 @@ def test_save_settings_path_map_round_trip_into_protocol_setup(tmp_path: Path) -
 
     # Create test image and dummy protocol files
     _create_test_image(images_folder / "img_0001.JPG", now)
-    imaging_csv.write_text("path,image_id,datetime\nimg_0001.JPG,1,2023-11-15 12:00:00")
+    imaging_csv.write_text("path,datetime\nimg_0001.JPG,2023-11-15 12:00:00")
     injection_csv.write_text(
         "id,location_x,location_y,start,end,rate_kg/s\n1,0.5,0.5,00:00:00,01:00:00,0.0"
     )
@@ -191,9 +191,8 @@ def test_save_settings_path_map_round_trip_into_protocol_setup(tmp_path: Path) -
     df = pd.read_csv(imaging_csv)
     assert set(df.columns) == {
         "path",
-        "image_id",
         "datetime",
-    }, f"Expected columns {{path, image_id, datetime}}, got {set(df.columns)}"
-    assert df["image_id"].tolist() == [
-        1
-    ], f"Expected image_id=[1], got {df['image_id'].tolist()}"
+    }, f"Expected columns {{path, datetime}}, got {set(df.columns)}"
+    assert df["path"].tolist() == [
+        "img_0001.JPG"
+    ], f"Expected path=['img_0001.JPG'], got {df['path'].tolist()}"

--- a/tests/unit/test_protocolled_experiment_performance.py
+++ b/tests/unit/test_protocolled_experiment_performance.py
@@ -55,7 +55,7 @@ def _touch_images(folder: Path, count: int) -> list[Path]:
     return paths
 
 
-def test_imaging_protocol_prefers_path_match_and_uses_blacklist_index(
+def test_imaging_protocol_matches_by_path_and_blacklist(
     tmp_path: Path,
 ) -> None:
     start = datetime(2026, 1, 1, 0, 0, 0)
@@ -66,19 +66,13 @@ def test_imaging_protocol_prefers_path_match_and_uses_blacklist_index(
         [
             {
                 "path": "sub/img_00999.JPG",
-                "image_id": 999,
                 "datetime": (start + timedelta(hours=5)).isoformat(),
-            },
-            {
-                "path": "",
-                "image_id": 1,
-                "datetime": (start + timedelta(hours=1)).isoformat(),
             },
         ],
     )
-    pd.DataFrame({"image_id": [999]}).to_csv(blacklist_path, index=False)
+    pd.DataFrame({"path": ["sub/img_00999.JPG"]}).to_csv(blacklist_path, index=False)
 
-    protocol = ImagingProtocol(protocol_path, pad=5, blacklist=blacklist_path)
+    protocol = ImagingProtocol(protocol_path, blacklist=blacklist_path)
     dt = protocol.get_datetime(tmp_path / "sub" / "img_00999.JPG")
     assert dt == pd.Timestamp(start + timedelta(hours=5))
     assert protocol.is_blacklisted(tmp_path / "sub" / "img_00999.JPG")
@@ -105,7 +99,6 @@ def test_find_images_for_times_uses_deepest_folder_mapping_and_deduplicates(
         [
             {
                 "path": f"img_{i:05d}.JPG",
-                "image_id": i,
                 "datetime": (start + timedelta(hours=i)).isoformat(),
             }
             for i in range(1, 4)
@@ -116,7 +109,6 @@ def test_find_images_for_times_uses_deepest_folder_mapping_and_deduplicates(
         [
             {
                 "path": f"sub/img_{i:05d}.JPG",
-                "image_id": i,
                 "datetime": (start + timedelta(hours=100 + i)).isoformat(),
             }
             for i in range(1, 4)
@@ -129,7 +121,6 @@ def test_find_images_for_times_uses_deepest_folder_mapping_and_deduplicates(
         injection_protocol=injection_path,
         pressure_temperature_protocol=pressure_path,
         blacklist_protocol=None,
-        pad=5,
     )
 
     selected = experiment.find_images_for_times(times=[101.1, 101.2], data=sub_images)
@@ -153,7 +144,6 @@ def test_find_images_for_times_reuses_cached_timeline_for_same_data_pool(
         [
             {
                 "path": f"img_{i:05d}.JPG",
-                "image_id": i,
                 "datetime": (start + timedelta(hours=i)).isoformat(),
             }
             for i in range(1, 1001)
@@ -166,7 +156,6 @@ def test_find_images_for_times_reuses_cached_timeline_for_same_data_pool(
         injection_protocol=injection_path,
         pressure_temperature_protocol=pressure_path,
         blacklist_protocol=None,
-        pad=5,
     )
 
     call_count = 0
@@ -209,7 +198,6 @@ def test_iter_available_resolves_protocol_once_per_path(
         [
             {
                 "path": f"img_{i:05d}.JPG",
-                "image_id": i,
                 "datetime": (start + timedelta(hours=i)).isoformat(),
             }
             for i in range(1, 3)
@@ -220,7 +208,6 @@ def test_iter_available_resolves_protocol_once_per_path(
         [
             {
                 "path": f"sub/img_{i:05d}.JPG",
-                "image_id": i,
                 "datetime": (start + timedelta(hours=100 + i)).isoformat(),
             }
             for i in range(1, 3)
@@ -233,7 +220,6 @@ def test_iter_available_resolves_protocol_once_per_path(
         injection_protocol=injection_path,
         pressure_temperature_protocol=pressure_path,
         blacklist_protocol=None,
-        pad=5,
     )
 
     call_count = 0

--- a/tests/unit/test_setup_protocols.py
+++ b/tests/unit/test_setup_protocols.py
@@ -63,8 +63,8 @@ def test_setup_imaging_protocol_generates_all_csv_templates(tmp_path: Path) -> N
     assert pressure_path.exists()
 
     imaging_df = pd.read_csv(imaging_path)
-    assert set(imaging_df.columns) == {"path", "image_id", "datetime"}
-    assert imaging_df["image_id"].tolist() == [1, 2]
+    assert set(imaging_df.columns) == {"path", "datetime"}
+    assert imaging_df["path"].tolist() == ["img_0001.JPG", "img_0002.JPG"]
 
     injection_df = pd.read_csv(injection_path)
     assert set(injection_df.columns) == {


### PR DESCRIPTION
Tighten design of a imaging protocol to a minimum. Image_id's based on extraction a number was not safe due to the need for padding in path names. This cannot be guaranteed.